### PR TITLE
Various fixes (Needed for MusicJSON npm package)

### DIFF
--- a/lib/DOMImplementation.js
+++ b/lib/DOMImplementation.js
@@ -4,6 +4,7 @@ var Document = require('./Document');
 var DocumentType = require('./DocumentType');
 var HTMLParser = require('./HTMLParser');
 var utils = require('./utils');
+var xml = require('./xmlnames');
 
 // Each document must have its own instance of the domimplementation object
 // Even though these objects have no state

--- a/lib/Document.js
+++ b/lib/Document.js
@@ -518,7 +518,8 @@ Document.prototype = Object.create(Node.prototype, {
       this.byId[id] = n;
     }
     else {
-      console.warn('Duplicate element id ' + id);
+      // TODO: Add a way to opt-out console warnings
+      //console.warn('Duplicate element id ' + id);
       if (!Array.isArray(val)) {
         val = [val];
         this.byId[id] = val;

--- a/lib/Node.js
+++ b/lib/Node.js
@@ -564,10 +564,20 @@ Node.prototype = Object.create(EventTarget.prototype, {
         s += '<!--' + kid.data + '-->';
         break;
       case 7: //PROCESSING_INSTRUCTION_NODE
-        s += '<?' + kid.target + ' ' + kid.data + '>';
+        s += '<?' + kid.target + ' ' + kid.data + '?>';
         break;
       case 10: //DOCUMENT_TYPE_NODE
-        s += '<!DOCTYPE ' + kid.name + '>';
+        s += '<!DOCTYPE ' + kid.name;
+
+        if (kid.publicID) {
+          s += ' PUBLIC "' + kid.publicId + '"';
+        }
+
+        if (kid.systemId) {
+          s += ' "' + kid.systemId + '"';
+        }
+
+        s += '>';
         break;
       default:
         utils.InvalidState();

--- a/lib/ProcessingInstruction.js
+++ b/lib/ProcessingInstruction.js
@@ -1,3 +1,5 @@
+module.exports = ProcessingInstruction;
+
 var Node = require('./Node');
 var Leaf = require('./Leaf');
 


### PR DESCRIPTION
Hey fgnass and thanks a lot for doing this!

I've been having troubles with JSDom, and when I found out that dom.js had been forked and made available for Node.js I exulted!

There's however a few (quite annoying) bugs in the code, probably due to the massive restructuring work you must have done - which ends up being pretty annoying.

Fx a MusicXML document uses the same `id` attribute several times in a document for reference. When `domino` parses this XML document, it warns (in the console): "Duplicate element id ' + id". This is a show-stopper for me, since that leaves it impossible to write a command line tool, that can output to stdout (the TTY).

Furthermore, it was impossible to use the method `DOMImplementation#createDocumentType` as `xmlnames.js` hadn't been included in the document.

The two last changes are about the serializing of a document. A `ProcessingInstruction` should to my understanding end with `... ?>` and not just `... >`. And furthermore the DOCTYPE element didn't write out its public and system ID.

I hope that you'll take in these fixes, or else comment on what's wrong with them.

Thanks a lot again for doing this great job!
