### PR TITLE
Mirror Node type properties into Node.prototype.  (github #14)

### DIFF
--- a/lib/Node.js
+++ b/lib/Node.js
@@ -585,8 +585,22 @@ Node.prototype = Object.create(EventTarget.prototype, {
     }
 
     return s;
-  }}
+  }},
 
+  // mirror node type properties in the prototype, so they are present
+  // in instances of Node (and subclasses)
+  ELEMENT_NODE:                { value: ELEMENT_NODE },
+  ATTRIBUTE_NODE:              { value: ATTRIBUTE_NODE },
+  TEXT_NODE:                   { value: TEXT_NODE },
+  CDATA_SECTION_NODE:          { value: CDATA_SECTION_NODE },
+  ENTITY_REFERENCE_NODE:       { value: ENTITY_REFERENCE_NODE },
+  ENTITY_NODE:                 { value: ENTITY_NODE },
+  PROCESSING_INSTRUCTION_NODE: { value: PROCESSING_INSTRUCTION_NODE },
+  COMMENT_NODE:                { value: COMMENT_NODE },
+  DOCUMENT_NODE:               { value: DOCUMENT_NODE },
+  DOCUMENT_TYPE_NODE:          { value: DOCUMENT_TYPE_NODE },
+  DOCUMENT_FRAGMENT_NODE:      { value: DOCUMENT_FRAGMENT_NODE },
+  NOTATION_NODE:               { value: NOTATION_NODE }
 });
 
 function escape(s) {


### PR DESCRIPTION
Webkit defines document.ELEMENT_NODE, but domino previously defined
only Node.ELEMENT_NODE.  This patch adds the node types to Node.prototype
so that they are inherited by instances of Node and its subclasses.
