### PR TITLE
Only add newlines after <pre>/<textarea>/<listing> if necessary.

### DIFF
--- a/lib/Node.js
+++ b/lib/Node.js
@@ -543,9 +543,10 @@ Node.prototype = Object.create(EventTarget.prototype, {
         s += '>';
 
         if (!(html && emptyElements[tagname])) {
-          if (html && extraNewLine[tagname]) s += '\n';
+          var ss = kid.serialize();
+          if (html && extraNewLine[tagname] && ss.charAt(0)==='\n') s += '\n';
           // Serialize children and add end tag for all others
-          s += kid.serialize();
+          s += ss;
           s += '</' + tagname + '>';
         }
         break;


### PR DESCRIPTION
The HTML5 serialization spec at
http://www.whatwg.org/specs/web-apps/current-work/multipage/the-end.html#serializing-html-fragments
states that:

"If current node is a pre, textarea, or listing element, and the first
child node of the element, if any, is a Text node **whose character data
has as its first character** a U+000A LINE FEED (LF) character, then
append a U+000A LINE FEED (LF) character."

Currently domino always appends a newline after pre/textarea/listing.
This patch fixes domino to match the WHATWG spec, only adding a newline
where it is necessary to maintain the proper value of the contents.
(Since an initial newline is silently discarded when it follows a
pre/textarea/listing.)

Closes gh #16.
