### PR TITLE
Fix querySelectorAll() on unparented Elements.

### DIFF
--- a/lib/Element.js
+++ b/lib/Element.js
@@ -681,12 +681,7 @@ Element.prototype = Object.create(Node.prototype, {
   }},
 
   querySelectorAll: { value: function(selector) {
-    var self = this;
-    if (!this.parentNode) {
-      self = this.ownerDocument.createElement("div");
-      self.appendChild(this);
-    }
-    var nodes = select(selector, self);
+    var nodes = select(selector, this);
     return nodes.item ? nodes : new NodeList(nodes);
   }}
 

--- a/test/domino.js
+++ b/test/domino.js
@@ -24,6 +24,13 @@ exports.qsaOrder = function() {
   .should.eql(['H2', 'H3', 'H3', 'H2', 'H3']);
 }
 
+exports.orphanQSA = function() {
+  var document = domino.createDocument('<h1>foo</h1>');
+  var p = document.createElement('p');
+  p.querySelectorAll('p').should.have.length(0);
+  p.querySelectorAll('p').should.have.length(0);
+};
+
 exports.evilHandler = function() {
   var window = domino.createDocument('<a id="a" onclick="alert(\'breakin&#39;-stuff\')">');
 }


### PR DESCRIPTION
This removed code dated back to when domino used Sizzle as its selector
implementation.  It caused the first querySelectorAll() on an unparented
Element to parent the node and then run the query on the parent node,
with surprising results.
