### PR TITLE
Add require for missing utils module

### DIFF
--- a/lib/DOMTokenList.js
+++ b/lib/DOMTokenList.js
@@ -1,5 +1,5 @@
 // DOMTokenList implementation based on https://github.com/Raynos/DOM-shim
-utils = require('./utils');
+var utils = require('./utils');
 
 module.exports = DOMTokenList;
 


### PR DESCRIPTION
Ran into this while doing some testing. Utils gets used in `handleErrors`
