### PR TITLE
Fix Document.title to match DOM spec (create <title> if missing).

### DIFF
--- a/lib/Document.js
+++ b/lib/Document.js
@@ -331,13 +331,19 @@ Document.prototype = Object.create(Node.prototype, {
   lastModified: { get: utils.nyi },
   title: {
     get: function() {
-      // Return the test of the first <title> child of the <head> element.
+      // Return the text of the first <title> child of the <head> element.
       var elt = namedHTMLChild(this.head, 'title');
       return elt && elt.textContent || '';
     },
     set: function(value) {
-      var elt = namedHTMLChild(this.head, 'title');
-      if (elt) elt.textContent = value;
+      var head = this.head;
+      if (!head) { return; /* according to spec */ }
+      var elt = namedHTMLChild(head, 'title');
+      if (!elt) {
+        elt = this.createElement('title');
+        head.appendChild(elt);
+      }
+      elt.textContent = value;
     }
   },
   dir:  { get: utils.nyi, set: utils.nyi },

--- a/test/domino.js
+++ b/test/domino.js
@@ -62,6 +62,34 @@ exports.evilHandler = function() {
   var window = domino.createDocument('<a id="a" onclick="alert(\'breakin&#39;-stuff\')">');
 }
 
+exports.title = function() {
+  var d = domino.createDocument(html);
+  if (d.head) { d.documentElement.removeChild(d.head); }
+  d.should.have.property('head', null);
+  d.should.have.property('title', '');
+  d.querySelectorAll('head > title').should.have.length(0);
+
+  // per the spec, if there is no <head>, then setting Document.title should
+  // be a no-op.
+  d.title = "Lorem!";
+  d.title.should.equal('');
+  d.querySelectorAll('head > title').should.have.length(0);
+
+  // but if there is a <head>, then setting Document.title should create the
+  // <title> element if necessary.
+  d.documentElement.insertBefore(d.createElement('head'), d.body);
+  d.head.should.not.equal(null);
+  d.title.should.equal('');
+  d.title = "Lorem!";
+  d.title.should.equal("Lorem!");
+  d.querySelectorAll('head > title').should.have.length(1);
+
+  // verify that setting <title> works if there's already a title
+  d.title = "ipsum";
+  d.title.should.equal("ipsum");
+  d.querySelectorAll('head > title').should.have.length(1); // still only 1!
+};
+
 exports.children = function() {
   var d = domino.createDocument(html);
   var c = d.body.children;


### PR DESCRIPTION
domino would do a no-op for "document.title = ...." if there wasn't already a <title> element in the document's <head>.  Fix the behavior to match the DOM spec (http://www.whatwg.org/specs/web-apps/current-work/#the-title-element-0).
