### PR TITLE
Fix old call to toLowerCase() function.

### DIFF
--- a/lib/HTMLParser.js
+++ b/lib/HTMLParser.js
@@ -1484,7 +1484,7 @@ function isHTMLIntegrationPoint(n) {
   if (n.namespaceURI === NAMESPACE.MATHML &&
     n.localName === "annotation-xml") {
     var encoding = n.getAttribute("encoding");
-    if (encoding) encoding = toLowerCase(encoding);
+    if (encoding) encoding = encoding.toLowerCase();
     if (encoding === "text/html" ||
       encoding === "application/xhtml+xml")
       return true;


### PR DESCRIPTION
Originally dom.js "snapshotted" standard methods of JS objects at startup,
in order to protect itself from user monkey-patching.  (See src/snapshot.js
in dom.js.)  This was reverted when domino was forked from dom.js, since
domino doesn't try to protect itself from malicious user code --- but one
case managed to sneak through.  Fix it!
