### PR TITLE
Include <th> elements in HTMLTableRowElement.cells

### DIFF
--- a/lib/htmlelts.js
+++ b/lib/htmlelts.js
@@ -944,7 +944,7 @@ define({
   },
   props: {
     cells: { get: function() {
-      return this.getElementsByTagName('td');
+      return this.querySelectorAll('td,th');
     }}
   }
 });


### PR DESCRIPTION
See:
- http://www.w3.org/TR/REC-html40/struct/tables.html#h-11.2.6
- http://www.w3.org/TR/REC-DOM-Level-1/level-one-html.html#ID-82915075
- http://www.w3.org/TR/html5/tabular-data.html#dom-tr-cells
- http://www.whatwg.org/specs/web-apps/current-work/multipage/tabular-data.html#dom-tr-cells
