### PR TITLE
Performance tweak: Add fast path to escapeAttr

### DIFF
--- a/lib/Node.js
+++ b/lib/Node.js
@@ -614,13 +614,19 @@ function escape(s) {
 }
 
 function escapeAttr(s) {
-  return s.replace(/[&"\u00A0]/g, function(c) {
-    switch(c) {
-    case '&': return '&amp;';
-    case '"': return '&quot;';
-    case '\u00A0': return '&nbsp;';
-    }
-  });
+  var toEscape = /[&"\u00A0]/g;
+  if (!toEscape.test(s)) {
+	  // nothing to do, fast path
+	  return s;
+  } else {
+	  return s.replace(toEscape, function(c) {
+		switch(c) {
+		case '&': return '&amp;';
+		case '"': return '&quot;';
+		case '\u00A0': return '&nbsp;';
+		}
+	  });
+  }
 }
 
 function attrname(a) {


### PR DESCRIPTION
At least in node 0.10 a test is cheaper than constructing a new string with
replace. Since the common case for attributes is that there's nothing to
escape, it makes sense to add a fast path that leaves the string untouched.
