### PR TITLE
Performance: Parse attribute values in bulk

### DIFF
--- a/lib/HTMLParser.js
+++ b/lib/HTMLParser.js
@@ -1438,6 +1438,10 @@ var CHARREF = /^#[0-9]+[^0-9]|^#[xX][0-9a-fA-F]+[^0-9a-fA-F]|^[a-zA-Z][a-zA-Z0-9
 // Like the above, but for named char refs, the last char can't be =
 var ATTRCHARREF = /^#[0-9]+[^0-9]|^#[xX][0-9a-fA-F]+[^0-9a-fA-F]|^[a-zA-Z][a-zA-Z0-9]*[^=a-zA-Z0-9]/;
 
+var DBLQUOTEATTRVAL = /[^"&\u0000]+/g
+var SINGLEQUOTEATTRVAL = /[^'&\u0000]+/g
+var UNQUOTEDATTRVAL = /[^\t\r\n &>\u0000]+/g
+
 var DATATEXT = /[^&<\r\u0000\uffff]*/g;
 var RAWTEXT = /[^<\r\u0000\uffff]*/g;
 var PLAINTEXT = /[^\r\u0000\uffff]*/g;
@@ -1857,7 +1861,7 @@ function HTMLParser(address, fragmentContext, options) {
   var lasttagname = ""; // holds the target end tag for text states
   var tempbuf = [];
   var attrnamebuf = [];
-  var attrvaluebuf = [];
+  var attrvaluebuf = '';
   var commentbuf = [];
   var doctypenamebuf = [];
   var doctypepublicbuf = [];
@@ -2245,7 +2249,7 @@ function HTMLParser(address, fragmentContext, options) {
     }
 
     if (valuebuf) {
-      attributes.push([name, buf2str(valuebuf)]);
+      attributes.push([name, valuebuf]);
     }
     else {
       attributes.push([name]);
@@ -2300,7 +2304,7 @@ function HTMLParser(address, fragmentContext, options) {
 
   function beginTempBuf() { tempbuf.length = 0; }
   function beginAttrName() { attrnamebuf.length = 0; }
-  function beginAttrValue() { attrvaluebuf.length = 0; }
+  function beginAttrValue() { attrvaluebuf = ''; }
   function beginComment() { commentbuf.length = 0; }
   function beginDoctype() {
     doctypenamebuf.length = 0;
@@ -2340,6 +2344,21 @@ function HTMLParser(address, fragmentContext, options) {
       textIncludesNUL = false;
     }
     ignore_linefeed = false;
+  }
+
+  // Consume chars matched by the pattern and return them as a string. Starts
+  // matching at the current position, so users should drop the current char
+  // otherwise.
+  function getMatchingChars(pattern) {
+      pattern.lastIndex = nextchar - 1;
+      var match = pattern.exec(chars);
+      if (match && match.index === nextchar - 1) {
+          match = match[0];
+          nextchar += match.length - 1;
+          return match;
+      } else {
+          return '';
+      }
   }
 
   // emit a string of chars that match a regexp
@@ -3281,7 +3300,8 @@ function HTMLParser(address, fragmentContext, options) {
       break;
     default:
       tagnamebuf.push(c);
-      // appendCharsWhile(tagnamebuf, TAGNAMECHARS) || tagnamebuf.push(c);
+      // XXX: For more performance, try switching tagnamebuf to a string and
+      // use getMatchingChars
       break;
     }
   }
@@ -4168,7 +4188,7 @@ function HTMLParser(address, fragmentContext, options) {
       tokenizer = attribute_value_single_quoted_state;
       break;
     case 0x0000: // NULL
-      attrvaluebuf.push(0xFFFD /* REPLACEMENT CHARACTER */);
+      attrvaluebuf += String.fromCharCode(0xFFFD /* REPLACEMENT CHARACTER */);
       tokenizer = attribute_value_unquoted_state;
       break;
     case 0x003E: // GREATER-THAN SIGN
@@ -4185,7 +4205,7 @@ function HTMLParser(address, fragmentContext, options) {
     case 0x0060: // GRAVE ACCENT
       /* falls through */
     default:
-      attrvaluebuf.push(c);
+      attrvaluebuf += String.fromCharCode(c);
       tokenizer = attribute_value_unquoted_state;
       break;
     }
@@ -4202,15 +4222,14 @@ function HTMLParser(address, fragmentContext, options) {
       tokenizer = character_reference_in_attribute_value_state;
       break;
     case 0x0000: // NULL
-      attrvaluebuf.push(0xFFFD /* REPLACEMENT CHARACTER */);
+      attrvaluebuf += String.fromCharCode(0xFFFD /* REPLACEMENT CHARACTER */);
       break;
     case -1: // EOF
       nextchar--; // pushback
       tokenizer = data_state;
       break;
     default:
-      attrvaluebuf.push(c);
-      // appendCharsWhile(attrvaluebuf, DBLQUOTEATTRVAL);
+      attrvaluebuf += getMatchingChars(DBLQUOTEATTRVAL);
       break;
     }
   }
@@ -4226,15 +4245,14 @@ function HTMLParser(address, fragmentContext, options) {
       tokenizer = character_reference_in_attribute_value_state;
       break;
     case 0x0000: // NULL
-      attrvaluebuf.push(0xFFFD /* REPLACEMENT CHARACTER */);
+      attrvaluebuf += String.fromCharCode(0xFFFD /* REPLACEMENT CHARACTER */);
       break;
     case -1: // EOF
       nextchar--; // pushback
       tokenizer = data_state;
       break;
     default:
-      attrvaluebuf.push(c);
-      // appendCharsWhile(attrvaluebuf, SINGLEQUOTEATTRVAL);
+      attrvaluebuf += getMatchingChars(SINGLEQUOTEATTRVAL);
       break;
     }
   }
@@ -4258,7 +4276,7 @@ function HTMLParser(address, fragmentContext, options) {
       emitTag();
       break;
     case 0x0000: // NULL
-      attrvaluebuf.push(0xFFFD /* REPLACEMENT CHARACTER */);
+      attrvaluebuf += String.fromCharCode(0xFFFD /* REPLACEMENT CHARACTER */);
       break;
     case -1: // EOF
       nextchar--; // pushback
@@ -4271,8 +4289,7 @@ function HTMLParser(address, fragmentContext, options) {
     case 0x0060: // GRAVE ACCENT
       /* falls through */
     default:
-      attrvaluebuf.push(c);
-      // appendCharsWhile(attrvaluebuf, UNQUOTEDATTRVAL);
+      attrvaluebuf += getMatchingChars(UNQUOTEDATTRVAL);
       break;
     }
   }
@@ -4281,16 +4298,14 @@ function HTMLParser(address, fragmentContext, options) {
     var char = parseCharRef(lookahead, true);
     if (char !== null) {
       if (typeof char === "number")
-        attrvaluebuf.push(char);
+        attrvaluebuf += String.fromCharCode(char);
       else {
         // An array of numbers
-        for(var i = 0; i < char.length; i++) {
-          attrvaluebuf.push(char[i]);
-        }
+        attrvaluebuf += String.fromCharCode.apply(String, char);
       }
     }
     else {
-      attrvaluebuf.push(0x0026); // AMPERSAND;
+      attrvaluebuf += '&'; // AMPERSAND;
     }
 
     popState();


### PR DESCRIPTION
Profiling (using https://github.com/gwicke/nodegrind) showed that parsing time on documents with large quoted attribute
values was dominated by buf2str. This patch addresses this by accumulating
attribute values in a string, and extracting the bulk of the value with
regexps to avoid the conversion to and from char codes.

On a large document with several data attributes
(http://parsoid-lb.eqiad.wikimedia.org/enwiki/Barack_Obama?oldid=608145977)
parse times drop from around 564ms to about 351.
