### PR TITLE
Fix breakage from 400b989d

### DIFF
--- a/lib/HTMLParser.js
+++ b/lib/HTMLParser.js
@@ -1454,8 +1454,8 @@ var PLAINTEXT = /[^\r\u0000\uffff]*/g;
 // us from scanning past the lastIndex set. (Note that the desired matches
 // are always greater than 1 char long, so longest-match will ensure that .
 // is not matched unless the desired match fails.)
-var SIMPLETAG = /(?:(\/)?([a-z]+)>)|./g;
-var SIMPLEATTR = /(?:([-a-z]+) *= *('[^'&\r\u0000]*'|"[^"&\r\u0000]*"|[^&> \t\n\r\f\u0000]+[ \t\n\f]))|./g;
+var SIMPLETAG = /(?:(\/)?([a-z]+)>)/g;
+var SIMPLEATTR = /(?:([-a-z]+) *= *('[^'&\r\u0000]*'|"[^"&\r\u0000]*"|[^&> \t\n\r\f\u0000]+[ \t\n\f]))/g;
 
 var NONWS = /[^\x09\x0A\x0C\x0D\x20]/;
 var ALLNONWS = /[^\x09\x0A\x0C\x0D\x20]/g; // like above, with g flag
@@ -2266,9 +2266,8 @@ function HTMLParser(address, fragmentContext, options) {
   function handleSimpleAttribute() {
     SIMPLEATTR.lastIndex = nextchar-1;
     var matched = SIMPLEATTR.exec(chars);
-    if (!matched) throw new Error("should never happen");
+    if (!matched || SIMPLETAG.lastIndex !== nextchar - 1) return false;
     var name = matched[1];
-    if (!name) return false;
     var value = matched[2];
     var len = value.length;
     switch(value[0]) {
@@ -2405,9 +2404,8 @@ function HTMLParser(address, fragmentContext, options) {
   function emitSimpleTag() {
     SIMPLETAG.lastIndex = nextchar;
     var matched = SIMPLETAG.exec(chars);
-    if (!matched) throw new Error("should never happen");
+    if (!matched || SIMPLETAG.lastIndex !== nextchar) return false;
     var tagname = matched[2];
-    if (!tagname) return false;
     var endtag = matched[1];
     if (endtag) {
       nextchar += (tagname.length+2);


### PR DESCRIPTION
Make sure to check whether lastIndex changed, and don't match any char in
SIMPLETAG / SIMPLEATTR regexp.

This broke Parsoid parser tests, but was not caught by the domino test suite.
This suggests a gap in test coverage.

TODO:
Add tests for this, or use a bigger HTML5 parser test suite.
