### PR TITLE
Be consistent with null namespace

### DIFF
--- a/lib/Element.js
+++ b/lib/Element.js
@@ -396,7 +396,7 @@ Element.prototype = Object.create(Node.prototype, {
   }},
 
   getAttributeNS: { value: function getAttributeNS(ns, lname) {
-    var attr = this._attrsByLName[ns + '|' + lname];
+    var attr = this._attrsByLName[(ns === null ? '' : ns) + '|' + lname];
     return attr ? attr.value : null;
   }},
 
@@ -406,7 +406,7 @@ Element.prototype = Object.create(Node.prototype, {
   }},
 
   hasAttributeNS: { value: function hasAttributeNS(ns, lname) {
-    var key = ns + '|' + lname;
+    var key = (ns === null ? '' : ns) + '|' + lname;
     return key in this._attrsByLName;
   }},
 
@@ -453,7 +453,7 @@ Element.prototype = Object.create(Node.prototype, {
       lname = qname.substring(pos+1);
     }
 
-    var key = ns + '|' + lname;
+    var key = (ns === null ? '' : ns) + '|' + lname;
     if (ns === '') ns = null;
 
     var attr = this._attrsByLName[key];
@@ -530,9 +530,10 @@ Element.prototype = Object.create(Node.prototype, {
       this._attrsByQName[qname] = undefined;
     }
 
+    var ns = attr.namespaceURI;
     // Now attr is the removed attribute.  Figure out its
     // ns+lname key and remove it from the other mapping as well.
-    var key = (attr.namespaceURI || '') + '|' + attr.localName;
+    var key = (ns === null ? '' : ns) + '|' + attr.localName;
     this._attrsByLName[key] = undefined;
 
     var i = this._attrKeys.indexOf(key);
@@ -550,7 +551,7 @@ Element.prototype = Object.create(Node.prototype, {
   }},
 
   removeAttributeNS: { value: function removeAttributeNS(ns, lname) {
-    var key = (ns || '') + '|' + lname;
+    var key = (ns === null ? '' : ns) + '|' + lname;
     var attr = this._attrsByLName[key];
     if (!attr) return;
 
@@ -599,7 +600,7 @@ Element.prototype = Object.create(Node.prototype, {
   // Create a new Attr object, insert it, and return it.
   // Used by setAttribute() and by set()
   _newattr: { value: function _newattr(qname) {
-    var attr = new Attr(this, qname);
+    var attr = new Attr(this, qname, null, null);
     var key = '|' + qname;
     this._attrsByQName[qname] = attr;
     this._attrsByLName[key] = attr;
@@ -723,8 +724,9 @@ function Attr(elt, lname, prefix, namespace) {
   // localName and namespace are constant for any attr object.
   // But value may change.  And so can prefix, and so, therefore can name.
   this.localName = lname;
-  this.prefix = prefix || null;
-  this.namespaceURI = namespace || null;
+  var nulls = [ "", null ];
+  this.prefix = (~nulls.indexOf( prefix ) ? null : String(prefix));
+  this.namespaceURI = (~nulls.indexOf( namespace ) ? null : String(namespace));
 }
 
 Attr.prototype = {


### PR DESCRIPTION
In some places it's being normalized as an empty string, but not everywhere. This leads to varying keys in the `_attrsBy*Name` maps.

```
null|stuff
|stuff
```
