### PR TITLE
CSS inheritance

### DIFF
--- a/lib/CSSStyleDeclaration.js
+++ b/lib/CSSStyleDeclaration.js
@@ -83,7 +83,15 @@ CSSStyleDeclaration.prototype = Object.create(Object.prototype, {
   }},
 
   getPropertyValue: { value: function(property) {
-    return this._parsed[property.toLowerCase()];
+    var parsedPropertyValue = this._parsed[property.toLowerCase()];
+    if (parsedPropertyValue !== undefined) {
+      // Return the requested style property if available...
+      return parsedPropertyValue;
+    }
+    else if (this._element.parentElement) {
+      // ...otherwise look for the first parent owning it
+      return this._element.parentElement.style.getPropertyValue(property);
+    }
   }},
 
   // XXX: for now we ignore !important declarations


### PR DESCRIPTION
Created this little patch to enable css inheritance: it will return the first parent's appropriate style property when an element does not have it (instead of undefined).