### PR TITLE
CSS inheritance

### DIFF
--- a/lib/CSSStyleDeclaration.js
+++ b/lib/CSSStyleDeclaration.js
@@ -88,8 +88,8 @@ CSSStyleDeclaration.prototype = Object.create(Object.prototype, {
       // Return the requested style property if available...
       return parsedPropertyValue;
     }
-    else if (this._element.parentElement) {
-      // ...otherwise look for the first parent owning it
+    else if (this._element.parentElement && isInheritedProperty(property)) {
+      // ...otherwise look for the first parent owning it in case of inherited property
       return this._element.parentElement.style.getPropertyValue(property);
     }
   }},
@@ -270,3 +270,52 @@ function defineStyleProperty(jsname) {
     }
   });
 }
+
+// Inherited properties according to http://www.w3.org/TR/CSS21/propidx.html
+var inheritedProperties = [
+  cssProperties.borderCollapse,
+  cssProperties.borderSpacing,
+  cssProperties.captionSide,
+  cssProperties.color,
+  cssProperties.cursor,
+  cssProperties.direction,
+  cssProperties.elevation,
+  cssProperties.emptyCells,
+  cssProperties.fontFamily,
+  cssProperties.fontSize,
+  cssProperties.fontStyle,
+  cssProperties.fontVariant,
+  cssProperties.fontWeight,
+  cssProperties.font,
+  cssProperties.letterSpacing,
+  cssProperties.lineHeight,
+  cssProperties.listStyleImage,
+  cssProperties.listStylePosition,
+  cssProperties.listStyleType,
+  cssProperties.listStyle,
+  cssProperties.orphans,
+  cssProperties.pitchRange,
+  cssProperties.pitch,
+  cssProperties.quotes,
+  cssProperties.richness,
+  cssProperties.speakHeader,
+  cssProperties.speakNumeral,
+  cssProperties.speakPunctuation,
+  cssProperties.speak,
+  cssProperties.speechRate,
+  cssProperties.stress,
+  cssProperties.textAlign,
+  cssProperties.textIndent,
+  cssProperties.textTransform,
+  cssProperties.visibility,
+  cssProperties.voiceFamily,
+  cssProperties.volume,
+  cssProperties.whiteSpace,
+  cssProperties.widows,
+  cssProperties.wordSpacing
+];
+
+function isInheritedProperty(property) {
+  return inheritedProperties.indexOf(property) > -1;
+}
+

--- a/lib/CSSStyleDeclaration.js
+++ b/lib/CSSStyleDeclaration.js
@@ -83,7 +83,15 @@ CSSStyleDeclaration.prototype = Object.create(Object.prototype, {
   }},
 
   getPropertyValue: { value: function(property) {
-    return this._parsed[property.toLowerCase()];
+    var parsedPropertyValue = this._parsed[property.toLowerCase()];
+    if (parsedPropertyValue !== undefined) {
+      // Return the requested style property if available...
+      return parsedPropertyValue;
+    }
+    else if (this._element.parentElement) {
+      // ...otherwise look for the first parent owning it
+      return this._element.parentElement.style.getPropertyValue(property);
+    }
   }},
 
   // XXX: for now we ignore !important declarations


### PR DESCRIPTION
Created this little patch to enable css inheritance: it will return the first parent's appropriate style property when an element does not have it and the property itself is inheritable (instead of undefined).