### PR TITLE
Fix slow node insertion when IDs are duplicates

### DIFF
--- a/lib/Document.js
+++ b/lib/Document.js
@@ -786,6 +786,7 @@ MultiId.prototype.getFirst = function() {
 // If there is only one node left, return it. Otherwise return "this".
 MultiId.prototype.downgrade = function() {
   if (this.length == 1) {
+    var nid;
     for (nid in this.nodes) {
       return this.nodes[nid];
     }

--- a/lib/Document.js
+++ b/lib/Document.js
@@ -314,8 +314,8 @@ Document.prototype = Object.create(Node.prototype, {
   getElementById: { value: function(id) {
     var n = this.byId[id];
     if (!n) return null;
-    if (Array.isArray(n)) { // there was more than one element with this id
-      return n[0];  // array is sorted in document order
+    if (n instanceof MultiId) { // there was more than one element with this id
+      return n.getFirst();
     }
     return n;
   }},
@@ -564,12 +564,11 @@ Document.prototype = Object.create(Node.prototype, {
     else {
       // TODO: Add a way to opt-out console warnings
       //console.warn('Duplicate element id ' + id);
-      if (!Array.isArray(val)) {
-        val = [val];
+      if (!(val instanceof MultiId)) {
+        val = new MultiId(val);
         this.byId[id] = val;
       }
-      val.push(n);
-      val.sort(utils.documentOrder);
+      val.add(n);
     }
   }},
 
@@ -578,12 +577,10 @@ Document.prototype = Object.create(Node.prototype, {
     var val = this.byId[id];
     utils.assert(val);
 
-    if (Array.isArray(val)) {
-      var idx = val.indexOf(n);
-      val.splice(idx, 1);
-
+    if (val instanceof MultiId) {
+      val.del(n);
       if (val.length == 1) { // convert back to a single node
-        this.byId[id] = val[0];
+        this.byId[id] = val.downgrade();
       }
     }
     else {
@@ -742,4 +739,56 @@ function recursivelySetOwner(node, owner) {
   var kids = node.childNodes;
   for(var i = 0, n = kids.length; i < n; i++)
     recursivelySetOwner(kids[i], owner);
+}
+
+// A class for storing multiple nodes with the same ID
+function MultiId(node) {
+  this.nodes = {};
+  this.nodes[node._nid] = node;
+  this.length = 1;
+  this.firstNode = undefined;
+}
+
+// Add a node to the list, with O(1) time
+MultiId.prototype.add = function(node) {
+  if (!this.nodes[node._nid]) {
+    this.nodes[node._nid] = node;
+    this.length++;
+    this.firstNode = undefined;
+  }
+};
+
+// Remove a node from the list, with O(1) time
+MultiId.prototype.del = function(node) {
+  if (this.nodes[node._nid]) {
+    delete this.nodes[node._nid];
+    this.length--;
+    this.firstNode = undefined;
+  }
+};
+
+// Get the first node from the list, in the document order
+// Takes O(N) time in the size of the list, with a cache that is invalidated
+// when the list is modified.
+MultiId.prototype.getFirst = function() {
+  if (!this.firstNode) {
+    var nid;
+    for (nid in this.nodes) {
+      if (this.firstNode === undefined ||
+        this.firstNode.compareDocumentPosition(this.nodes[nid]) & Node.DOCUMENT_POSITION_PRECEDING) {
+        this.firstNode = this.nodes[nid];
+      }
+    }
+  }
+  return this.firstNode;
+};
+
+// If there is only one node left, return it. Otherwise return "this".
+MultiId.prototype.downgrade = function() {
+  if (this.length == 1) {
+    for (nid in this.nodes) {
+      return this.nodes[nid];
+    }
+  }
+  return this;
 }

--- a/lib/NodeIterator.js
+++ b/lib/NodeIterator.js
@@ -41,7 +41,7 @@ function traverse(ni, directionIsNext) {
         return null;
       }
     }
-    result = ni.filter.acceptNode(node);
+    var result = ni.filter.acceptNode(node);
     if (result === NodeFilter.FILTER_ACCEPT) {
       break;
     }

--- a/test/domino.js
+++ b/test/domino.js
@@ -420,3 +420,27 @@ exports.gh59 = function() {
   doc.querySelectorAll('span[style="display:none"]').should.have.length(1);
   doc.querySelectorAll('span[style*="display:none"]').should.have.length(1);
 };
+
+exports.duplicateID = function() {
+  var doc = domino.createDocument('<root></root>');
+  var root = doc.documentElement;
+
+  function makeElement(name) {
+    var elt = doc.createElement(name);
+    elt.setAttribute("id", "x");
+    return elt;
+  }
+
+  var a = root.appendChild(makeElement("a"));
+  var b = root.appendChild(makeElement("b"));
+  var c = root.appendChild(makeElement("c"));
+  var d = root.appendChild(makeElement("d"));
+  doc.getElementById("x").should.equal(a);
+  root.removeChild(a);
+  doc.getElementById("x").should.equal(b);
+  root.removeChild(c);
+  root.removeChild(b);
+  doc.getElementById("x").should.equal(d);
+  root.removeChild(d);
+  (doc.getElementById("x") === null).should.be.true();
+}

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -3,4 +3,4 @@
 --require should
 --slow 20
 --growl
-
+--check-leaks


### PR DESCRIPTION
In a real-world case where thousands of nodes with duplicate IDs were
inserted, performance in the node count was O(N^2 log N) due to the
need to sort the byId array after each insertion. So, store duplicates
in an object indexed by _nid. When getElementById() is called, do a
linear search for the earliest element in the document order and cache
the result.

This gives O(1) insertion, O(1) deletion and O(N) for an insert or
delete immediately followed by a get, in the pre-existing size of the
list, which is a better time order for all three cases than the existing
code.