### PR TITLE
Use `Object.create(null)` when using an object as a Map.

### DIFF
--- a/lib/Document.js
+++ b/lib/Document.js
@@ -50,7 +50,7 @@ function Document(isHTML, address) {
   // We may need to update this mapping every time a node is rooted
   // or uprooted, and any time an attribute is added, removed or changed
   // on a rooted element.
-  this.byId = {};
+  this.byId = Object.create(null);
 
   // This property holds a monotonically increasing value akin to
   // a timestamp used to record the last modification time of nodes
@@ -743,7 +743,7 @@ function recursivelySetOwner(node, owner) {
 
 // A class for storing multiple nodes with the same ID
 function MultiId(node) {
-  this.nodes = {};
+  this.nodes = Object.create(null);
   this.nodes[node._nid] = node;
   this.length = 1;
   this.firstNode = undefined;

--- a/lib/Element.js
+++ b/lib/Element.js
@@ -27,8 +27,8 @@ function Element(doc, localName, namespaceURI, prefix) {
   this.childNodes = new NodeList();
 
   // These properties maintain the set of attributes
-  this._attrsByQName = {}; // The qname->Attr map
-  this._attrsByLName = {}; // The ns|lname->Attr map
+  this._attrsByQName = Object.create(null); // The qname->Attr map
+  this._attrsByLName = Object.create(null); // The ns|lname->Attr map
   this._attrKeys = [];     // attr index -> ns|lname
 
   this._index = undefined;
@@ -806,7 +806,7 @@ ChildrenCollection.prototype = {
       }
 
       this.childrenByNumber = [];
-      this.childrenByName = {};
+      this.childrenByName = Object.create(null);
 
       for(i = 0, n = this.element.childNodes.length; i < n; i++) {
         var c = this.element.childNodes[i];

--- a/lib/EventTarget.js
+++ b/lib/EventTarget.js
@@ -24,7 +24,7 @@ EventTarget.prototype = {
   addEventListener: function addEventListener(type, listener, capture) {
     if (!listener) return;
     if (capture === undefined) capture = false;
-    if (!this._listeners) this._listeners = {};
+    if (!this._listeners) this._listeners = Object.create(null);
     if (!this._listeners[type]) this._listeners[type] = [];
     var list = this._listeners[type];
 
@@ -285,7 +285,7 @@ EventTarget.prototype = {
   // of event dispatch.
   //
   _setEventHandler: function _setEventHandler(type, handler) {
-    if (!this._handlers) this._handlers = {};
+    if (!this._handlers) this._handlers = Object.create(null);
     this._handlers[type] = handler;
   },
 

--- a/lib/HTMLParser.js
+++ b/lib/HTMLParser.js
@@ -133,8 +133,9 @@ var limitedQuirkyPublicIds = /^-\/\/W3C\/\/DTD XHTML 1\.0 Frameset\/\/|^-\/\/W3C
 
 // Element sets below. See the isA() function for a way to test
 // whether an element is a member of a set
-var specialSet = {};
+var specialSet = Object.create(null);
 specialSet[NAMESPACE.HTML] = {
+  __proto__: null,
   "address":true, "applet":true, "area":true, "article":true,
   "aside":true, "base":true, "basefont":true, "bgsound":true,
   "blockquote":true, "body":true, "br":true, "button":true,
@@ -157,53 +158,63 @@ specialSet[NAMESPACE.HTML] = {
   "ul":true, "wbr":true, "xmp":true
 };
 specialSet[NAMESPACE.SVG] = {
+  __proto__: null,
   "foreignObject": true, "desc": true, "title": true
 };
 specialSet[NAMESPACE.MATHML] = {
+  __proto__: null,
   "mi":true, "mo":true, "mn":true, "ms":true,
   "mtext":true, "annotation-xml":true
 };
 
 // The set of address, div, and p HTML tags
-var addressdivpSet = {};
+var addressdivpSet = Object.create(null);
 addressdivpSet[NAMESPACE.HTML] = {
+  __proto__: null,
   "address":true, "div":true, "p":true
 };
 
-var dddtSet = {};
+var dddtSet = Object.create(null);
 dddtSet[NAMESPACE.HTML] = {
+  __proto__: null,
   "dd":true, "dt":true
 };
 
-var tablesectionrowSet = {};
+var tablesectionrowSet = Object.create(null);
 tablesectionrowSet[NAMESPACE.HTML] = {
+  __proto__: null,
   "table":true, "thead":true, "tbody":true, "tfoot":true, "tr":true
 };
 
-var impliedEndTagsSet = {};
+var impliedEndTagsSet = Object.create(null);
 impliedEndTagsSet[NAMESPACE.HTML] = {
+  __proto__: null,
   "dd": true, "dt": true, "li": true, "option": true,
   "optgroup": true, "p": true, "rp": true, "rt": true
 };
 
 // See http://www.w3.org/TR/html5/forms.html#form-associated-element
-var formassociatedSet = {};
+var formassociatedSet = Object.create(null);
 formassociatedSet[NAMESPACE.HTML] = {
+  __proto__: null,
   "button": true, "fieldset": true, "input": true, "keygen": true,
   "label": true, "meter": true, "object": true, "output": true,
   "progress": true, "select": true, "textarea": true
 };
 
-var inScopeSet = {};
+var inScopeSet = Object.create(null);
 inScopeSet[NAMESPACE.HTML]= {
+  __proto__: null,
   "applet":true, "caption":true, "html":true, "table":true,
   "td":true, "th":true, "marquee":true, "object":true
 };
 inScopeSet[NAMESPACE.MATHML] = {
+  __proto__: null,
   "mi":true, "mo":true, "mn":true, "ms":true,
   "mtext":true, "annotation-xml":true
 };
 inScopeSet[NAMESPACE.SVG] = {
+  __proto__: null,
   "foreignObject":true, "desc":true, "title":true
 };
 
@@ -218,19 +229,22 @@ inButtonScopeSet[NAMESPACE.HTML] =
   Object.create(inScopeSet[NAMESPACE.HTML]);
 inButtonScopeSet[NAMESPACE.HTML].button = true;
 
-var inTableScopeSet = {};
+var inTableScopeSet = Object.create(null);
 inTableScopeSet[NAMESPACE.HTML] = {
+  __proto__: null,
   "html":true, "table":true
 };
 
 // The set of elements for select scope is the everything *except* these
-var invertedSelectScopeSet = {};
+var invertedSelectScopeSet = Object.create(null);
 invertedSelectScopeSet[NAMESPACE.HTML] = {
+  __proto__: null,
   "optgroup":true, "option":true
 };
 
-var mathmlTextIntegrationPointSet = {};
+var mathmlTextIntegrationPointSet = Object.create(null);
 mathmlTextIntegrationPointSet[NAMESPACE.MATHML] = {
+  __proto__: null,
   mi: true,
   mo: true,
   mn: true,
@@ -238,14 +252,16 @@ mathmlTextIntegrationPointSet[NAMESPACE.MATHML] = {
   mtext: true
 };
 
-var htmlIntegrationPointSet = {};
+var htmlIntegrationPointSet = Object.create(null);
 htmlIntegrationPointSet[NAMESPACE.SVG] = {
+  __proto__: null,
   foreignObject: true,
   desc: true,
   title: true
 };
 
 var foreignAttributes = {
+  __proto__: null,
   "xlink:actuate": NAMESPACE.XLINK, "xlink:arcrole": NAMESPACE.XLINK,
   "xlink:href":   NAMESPACE.XLINK,  "xlink:role":    NAMESPACE.XLINK,
   "xlink:show":   NAMESPACE.XLINK,  "xlink:title":   NAMESPACE.XLINK,
@@ -257,6 +273,7 @@ var foreignAttributes = {
 
 // Lowercase to mixed case mapping for SVG attributes and tagnames
 var svgAttrAdjustments = {
+  __proto__: null,
   attributename: "attributeName", attributetype: "attributeType",
   basefrequency: "baseFrequency", baseprofile: "baseProfile",
   calcmode: "calcMode", clippathunits: "clipPathUnits",
@@ -295,6 +312,7 @@ var svgAttrAdjustments = {
 };
 
 var svgTagNameAdjustments = {
+  __proto__: null,
   altglyph: "altGlyph", altglyphdef: "altGlyphDef",
   altglyphitem: "altGlyphItem", animatecolor: "animateColor",
   animatemotion: "animateMotion", animatetransform: "animateTransform",
@@ -322,6 +340,7 @@ var svgTagNameAdjustments = {
 // These next 3 objects are direct translations of tables
 // in the HTML spec into JavaScript object format
 var numericCharRefReplacements = {
+  __proto__: null,
   0x00:0xFFFD, 0x80:0x20AC, 0x82:0x201A, 0x83:0x0192, 0x84:0x201E,
   0x85:0x2026, 0x86:0x2020, 0x87:0x2021, 0x88:0x02C6, 0x89:0x2030,
   0x8A:0x0160, 0x8B:0x2039, 0x8C:0x0152, 0x8E:0x017D, 0x91:0x2018,
@@ -332,6 +351,7 @@ var numericCharRefReplacements = {
 
 // These named character references work even without the semicolon
 var namedCharRefsNoSemi = {
+  __proto__: null,
   "AElig":0xC6, "AMP":0x26, "Aacute":0xC1, "Acirc":0xC2,
   "Agrave":0xC0, "Aring":0xC5, "Atilde":0xC3, "Auml":0xC4,
   "COPY":0xA9, "Ccedil":0xC7, "ETH":0xD0, "Eacute":0xC9,
@@ -362,6 +382,7 @@ var namedCharRefsNoSemi = {
 };
 
 var namedCharRefs = {
+  __proto__: null,
   "AElig;":0xc6, "AMP;":0x26,
   "Aacute;":0xc1, "Abreve;":0x102,
   "Acirc;":0xc2, "Acy;":0x410,
@@ -6991,7 +7012,7 @@ function HTMLParser(address, fragmentContext, options) {
                !force_quirks]);
         break;
       case 2: // TAG
-        var attrs = {};
+        var attrs = Object.create(null);
         for(var i = 0; i < arg3.length; i++) {
           // XXX: does attribute order matter?
           var a = arg3[i];

--- a/lib/attributes.js
+++ b/lib/attributes.js
@@ -1,6 +1,6 @@
 exports.property = function(attr) {
   if (Array.isArray(attr.type)) {
-    var valid = {};
+    var valid = Object.create(null);
     attr.type.forEach(function(val) {
       valid[val.value || val] = val.alias || val;
     });

--- a/lib/cssparser.js
+++ b/lib/cssparser.js
@@ -39,7 +39,7 @@ function EventTarget(){
      * @property _listeners
      * @private
      */
-    this._listeners = {};    
+    this._listeners = Object.create(null);
 }
 
 EventTarget.prototype = {
@@ -559,7 +559,7 @@ function TokenStreamBase(input, tokenData){
 TokenStreamBase.createTokenData = function(tokens){
 
     var nameMap     = [],
-        typeMap     = {},
+        typeMap     = Object.create(null),
         tokenData     = tokens.concat([]),
         i            = 0,
         len            = tokenData.length+1;
@@ -5551,7 +5551,7 @@ var Tokens  = [
 (function(){
 
     var nameMap = [],
-        typeMap = {};
+        typeMap = Object.create(null);
     
     Tokens.UNKNOWN = -1;
     Tokens.unshift({name:"EOF"});

--- a/lib/htmlelts.js
+++ b/lib/htmlelts.js
@@ -7,7 +7,7 @@ var URLUtils = require('./URLUtils');
 var utils = require('./utils');
 
 var impl = exports.elements = {};
-var tagNameToImpl = {};
+var tagNameToImpl = Object.create(null);
 
 exports.createElement = function(doc, localName, prefix) {
   var impl = tagNameToImpl[localName] || HTMLUnknownElement;
@@ -51,7 +51,7 @@ function EventHandlerBuilder(body, document, form, element) {
 
 EventHandlerBuilder.prototype.build = function build() {
   try {
-    with(this.document.defaultView || {})
+    with(this.document.defaultView || Object.create(null))
       with(this.document)
         with(this.form)
           with(this.element)
@@ -63,8 +63,8 @@ EventHandlerBuilder.prototype.build = function build() {
 };
 
 function EventHandlerChangeHandler(elt, name, oldval, newval) {
-  var doc = elt.ownerDocument || {};
-  var form = elt.form || {};
+  var doc = elt.ownerDocument || Object.create(null);
+  var form = elt.form || Object.create(null);
   elt[name] = new EventHandlerBuilder(newval, doc, form, elt).build();
 }
 


### PR DESCRIPTION
This ensures that we don't see `hasOwnProperty` & etc as keys in the Map.

We will see `__proto__` as a key in the map with value `null`, but that's harmless in most cases (since we test for truthy map values).