### PR TITLE
Efficient implementation of replaceChild and fragment insertion

### DIFF
--- a/lib/Node.js
+++ b/lib/Node.js
@@ -148,10 +148,7 @@ Node.prototype = Object.create(EventTarget.prototype, {
     if (oldChild.parentNode !== parent) utils.NotFoundError();
     if (newChild.isAncestor(parent)) utils.HierarchyRequestError();
     parent.ensureSameDoc(newChild);
-
-    var refChild = oldChild.nextSibling;
-    oldChild.remove();
-    parent.insertBefore(newChild, refChild);
+    newChild._insertOrReplace(parent, oldChild.index, true);
     return oldChild;
   }},
 
@@ -374,9 +371,21 @@ Node.prototype = Object.create(EventTarget.prototype, {
   // Insert this node as a child of parent at the specified index,
   // firing mutation events as necessary
   insert: { value: function insert(parent, index) {
-    var child = this, kids = parent.childNodes;
+    this._insertOrReplace(parent, index, false);
+  }},
 
-    // If we are already a child of the specified parent, then t
+  // Insert this node as a child of parent at the specified index,
+  // or replace the specified child with this node, firing mutation events as
+  // necessary
+  _insertOrReplace: { value: function _insertOrReplace(parent, index, isReplace) {
+    var child = this;
+    var kids = parent.childNodes;
+
+    if (child.nodeType === DOCUMENT_FRAGMENT_NODE && child.rooted) {
+      utils.HierarchyRequestError();
+    }
+
+    // If we are already a child of the specified parent, then
     // the index may have to be adjusted.
     if (child.parentNode === parent) {
       var currentIndex = child.index;
@@ -390,16 +399,11 @@ Node.prototype = Object.create(EventTarget.prototype, {
       if (currentIndex < index) index--;
     }
 
-    // Special case for document fragments
-    // XXX: it is not at all clear that I'm handling this correctly.
-    // Scripts should never get to see partially
-    // inserted fragments, I think.  See:
-    // http://lists.w3.org/Archives/Public/www-dom/2011OctDec/0130.html
-    if (child.nodeType === DOCUMENT_FRAGMENT_NODE) {
-      var  c;
-      while((c = child.firstChild))
-        c.insert(parent, index++);
-      return;
+    // Delete the old child
+    if (isReplace) {
+      var oldChild = parent.childNodes[index];
+      if (oldChild.rooted) oldChild.doc.mutateRemove(oldChild);
+      oldChild.parentNode = undefined;
     }
 
     // If both the child and the parent are rooted, then we want to
@@ -407,34 +411,68 @@ Node.prototype = Object.create(EventTarget.prototype, {
     if (child.rooted && parent.rooted) {
       // Remove the child from its current position in the tree
       // without calling remove(), since we don't want to uproot it.
-      var curpar = child.parentNode, curidx = child.index;
-      child.parentNode.childNodes.splice(child.index, 1);
+      var curpar = child.parentNode;
+      curpar.childNodes.splice(child.index, 1);
       curpar.modify();
 
       // And insert it as a child of its new parent
       child.parentNode = parent;
-      kids.splice(index, 0, child);
-      child._index = index; // Optimization
+      if (isReplace) {
+        kids[index] = child;
+      } else {
+        kids.splice(index, 0, child);
+      }
+      child._index = index;
       parent.modify();
 
       // Generate a move mutation event
       parent.doc.mutateMove(child);
     }
     else {
-      // If the child already has a parent, it needs to be
-      // removed from that parent, which may also uproot it
-      if (child.parentNode) child.remove();
+      if (child.nodeType === DOCUMENT_FRAGMENT_NODE) {
+        var spliceArgs = [index, isReplace ? 1 : 0];
+        var i;
+        for (i = 0; i < child.childNodes.length; i++) {
+          var fragChild = child.childNodes[i];
+          spliceArgs.push(fragChild);
+          fragChild.parentNode = parent;
+          fragChild._index = index + i;
+        }
+        // Remove all nodes from the document fragment
+        child.childNodes.length = 0;
+        // Add all nodes to the new parent, overwriting the old child
+        kids.splice.apply(kids, spliceArgs);
+        // Call the mutation handlers
+        // Use spliceArgs since the original array has been destroyed. The 
+        // liveness guarantee requires us to clone the array so that
+        // references to the childNodes of the DocumentFragment will be empty
+        // when the insertion handlers are called.
+        if (parent.rooted) {
+          parent.modify();
+          for (i = 2; i < spliceArgs.length; i++) {
+            parent.doc.mutateInsert(spliceArgs[i]);
+          }
+        }
+      }
+      else {
+        // If the child already has a parent, it needs to be
+        // removed from that parent, which may also uproot it
+        if (child.parentNode) child.remove();
 
-      // Now insert the child into the parent's array of children
-      child.parentNode = parent;
-      kids.splice(index, 0, child);
+        // Now insert the child into the parent's array of children
+        child.parentNode = parent;
+        if (isReplace) {
+          kids[index] = child;
+        } else {
+          kids.splice(index, 0, child);
+        }
+        child._index = index;
 
-      child._index = index; // Optimization
-
-      // And root the child if necessary
-      if (parent.rooted) {
-        parent.modify();
-        parent.doc.mutateInsert(child);
+        // And root the child if necessary
+        if (parent.rooted) {
+          parent.modify();
+          parent.doc.mutateInsert(child);
+        }
       }
     }
   }},


### PR DESCRIPTION
Array.splice() is typically O(N) in the number of elements which need to be moved. This means that node insertion and removal can be very expensive. So:

* Implement replaceChild() by overwriting the relevant element in childNodes, instead of deleting and then re-inserting.
* Introduced a new helper function _insertOrReplace(), since the implementations now only differ in a few places.
* When inserting a document fragment, add the nodes to the array in bulk, with a single Array.splice(), instead of adding them one at a time. This also allows us to conveniently fix the fixme comment: document fragment insertion is now atomic from the point of view of mutation handlers.

Also:
* Remove unused variable curidx