### PR TITLE
Fix bug in stopping immediate propagation

### DIFF
--- a/lib/EventTarget.js
+++ b/lib/EventTarget.js
@@ -134,7 +134,7 @@ EventTarget.prototype = {
       if (!list) return;
       list = list.slice();
       for(var i = 0, n = list.length; i < n; i++) {
-        if (event._stopImmediatePropagation) return;
+        if (event._immediatePropagationStopped) return;
         var l = list[i];
         if ((phase === Event.CAPTURING_PHASE && !l.capture) ||
           (phase === Event.BUBBLING_PHASE && l.capture))


### PR DESCRIPTION
The wrong variable name was being checked, so domino would keep dispatching the event to more listeners on the same node after immediate propagation was stopped.