### PR TITLE
Fix broken stopping of immediate propagation

### DIFF
--- a/lib/EventTarget.js
+++ b/lib/EventTarget.js
@@ -134,7 +134,7 @@ EventTarget.prototype = {
       if (!list) return;
       list = list.slice();
       for(var i = 0, n = list.length; i < n; i++) {
-        if (event._stopImmediatePropagation) return;
+        if (event._immediatePropagationStopped) return;
         var l = list[i];
         if ((phase === Event.CAPTURING_PHASE && !l.capture) ||
           (phase === Event.BUBBLING_PHASE && l.capture))

--- a/test/htmlwg/submission/Ms2ger/events/event-handler-spec-example.html
+++ b/test/htmlwg/submission/Ms2ger/events/event-handler-spec-example.html
@@ -24,6 +24,8 @@ button.setAttribute('onclick', uncalled); // event handler listener is registere
 button.addEventListener('click', t.step_func(function () { assert_equals(++i, 3) }), false);
 button.onclick = t.step_func(function () { assert_equals(++i, 1); });
 button.addEventListener('click', t.step_func(function () { assert_equals(++i, 4) }), false);
+button.addEventListener('click', t.step_func(function (event) { event.stopImmediatePropagation() }), false);
+button.addEventListener('click', t.step_func(function (event) { ++i }), false);
 button.click()
 assert_equals(button.getAttribute("onclick"), uncalled)
 assert_equals(i, 4);


### PR DESCRIPTION
Stopping immediate propagation was not working because of a typo in the check that would have prevented the loop from continuing, so listeners that should not have been dispatched to were running their handlers inappropriately.