### PR TITLE
Add basic support for SVG api

### DIFF
--- a/lib/Document.js
+++ b/lib/Document.js
@@ -18,6 +18,7 @@ var select = require('./select');
 var events = require('./events');
 var xml = require('./xmlnames');
 var html = require('./htmlelts');
+var svg = require('./svg');
 var utils = require('./utils');
 var MUTATE = require('./MutationConstants');
 var NAMESPACE = utils.NAMESPACE;
@@ -160,9 +161,12 @@ Document.prototype = Object.create(Node.prototype, {
        qualifiedName !== 'xmlns' &&
        prefix !== 'xmlns'))
       utils.NamespaceError();
-
+      
     if (namespace === NAMESPACE.HTML) {
       return html.createElement(this, localName, prefix);
+    }
+    else if (namespace === NAMESPACE.SVG) {
+      return svg.createElement(this, localName, namespace, prefix);
     }
 
     return new Element(this, localName, namespace, prefix);

--- a/lib/Document.js
+++ b/lib/Document.js
@@ -161,12 +161,12 @@ Document.prototype = Object.create(Node.prototype, {
        qualifiedName !== 'xmlns' &&
        prefix !== 'xmlns'))
       utils.NamespaceError();
-      
+
     if (namespace === NAMESPACE.HTML) {
       return html.createElement(this, localName, prefix);
     }
     else if (namespace === NAMESPACE.SVG) {
-      return svg.createElement(this, localName, namespace, prefix);
+      return svg.createElement(this, localName, prefix);
     }
 
     return new Element(this, localName, namespace, prefix);

--- a/lib/defineElement.js
+++ b/lib/defineElement.js
@@ -1,0 +1,69 @@
+"use strict";
+
+var attributes = require('./attributes');
+var sloppy = require('./sloppy');
+
+module.exports = function(spec, defaultConstructor, tagList, tagNameToImpl) {
+  var c = spec.ctor;
+  if (c) {
+    var props = spec.props || {};
+
+    if (spec.attributes) {
+      for (var n in spec.attributes) {
+        var attr = spec.attributes[n];
+        if (typeof attr !== 'object' || Array.isArray(attr)) attr = {type: attr};
+        if (!attr.name) attr.name = n.toLowerCase();
+        props[n] = attributes.property(attr);
+      }
+    }
+
+    props.constructor = { value : c };
+    c.prototype = Object.create((spec.superclass || defaultConstructor).prototype, props);
+    if (spec.events) {
+      addEventHandlers(c, spec.events);
+    }
+    tagList[c.name] = c;
+  }
+  else {
+    c = defaultConstructor;
+  }
+
+  (spec.tags || spec.tag && [spec.tag] || []).forEach(function(tag) {
+    tagNameToImpl[tag] = c;
+  });
+
+  return c;
+};
+
+function EventHandlerBuilder(body, document, form, element) {
+  this.body = body;
+  this.document = document;
+  this.form = form;
+  this.element = element;
+}
+
+EventHandlerBuilder.prototype.build = sloppy.EventHandlerBuilder_build;
+
+function EventHandlerChangeHandler(elt, name, oldval, newval) {
+  var doc = elt.ownerDocument || Object.create(null);
+  var form = elt.form || Object.create(null);
+  elt[name] = new EventHandlerBuilder(newval, doc, form, elt).build();
+}
+
+function addEventHandlers(c, eventHandlerTypes) {
+  var p = c.prototype;
+  eventHandlerTypes.forEach(function(type) {
+    // Define the event handler registration IDL attribute for this type
+    Object.defineProperty(p, "on" + type, {
+      get: function() {
+        return this._getEventHandler(type);
+      },
+      set: function(v) {
+        this._setEventHandler(type, v);
+      },
+    });
+
+    // Define special behavior for the content attribute as well
+    attributes.registerChangeHandler(c, "on" + type, EventHandlerChangeHandler);
+  });
+}

--- a/lib/htmlelts.js
+++ b/lib/htmlelts.js
@@ -3,77 +3,19 @@ var Node = require('./Node');
 var Element = require('./Element');
 var CSSStyleDeclaration = require('./CSSStyleDeclaration');
 var utils = require('./utils');
-var attributes = require('./attributes');
 var URLUtils = require('./URLUtils');
-var sloppy = require('./sloppy');
+var defineElement = require('./defineElement');
 
-var impl = exports.elements = {};
-var tagNameToImpl = Object.create(null);
+var htmlElements = exports.elements = {};
+var htmlNameToImpl = Object.create(null);
 
 exports.createElement = function(doc, localName, prefix) {
-  var impl = tagNameToImpl[localName] || HTMLUnknownElement;
+  var impl = htmlNameToImpl[localName] || HTMLUnknownElement;
   return new impl(doc, localName, prefix);
 };
 
 function define(spec) {
-  var c = spec.ctor;
-  if (c) {
-    var props = spec.props || {};
-    if (spec.attributes) {
-      for (var n in spec.attributes) {
-        var attr = spec.attributes[n];
-        if (typeof attr !== 'object' || Array.isArray(attr)) attr = {type: attr};
-        if (!attr.name) attr.name = n.toLowerCase();
-        props[n] = attributes.property(attr);
-      }
-    }
-    props.constructor = { value : c };
-    c.prototype = Object.create((spec.superclass || HTMLElement).prototype, props);
-    if (spec.events) {
-      addEventHandlers(c, spec.events);
-    }
-    impl[c.name] = c;
-  }
-  else {
-    c = HTMLElement;
-  }
-  (spec.tags || spec.tag && [spec.tag] || []).forEach(function(tag) {
-    tagNameToImpl[tag] = c;
-  });
-  return c;
-}
-
-function EventHandlerBuilder(body, document, form, element) {
-  this.body = body;
-  this.document = document;
-  this.form = form;
-  this.element = element;
-}
-
-EventHandlerBuilder.prototype.build = sloppy.EventHandlerBuilder_build;
-
-function EventHandlerChangeHandler(elt, name, oldval, newval) {
-  var doc = elt.ownerDocument || Object.create(null);
-  var form = elt.form || Object.create(null);
-  elt[name] = new EventHandlerBuilder(newval, doc, form, elt).build();
-}
-
-function addEventHandlers(c, eventHandlerTypes) {
-  var p = c.prototype;
-  eventHandlerTypes.forEach(function(type) {
-    // Define the event handler registration IDL attribute for this type
-    Object.defineProperty(p, "on" + type, {
-      get: function() {
-        return this._getEventHandler(type);
-      },
-      set: function(v) {
-        this._setEventHandler(type, v);
-      },
-    });
-
-    // Define special behavior for the content attribute as well
-    attributes.registerChangeHandler(c, "on" + type, EventHandlerChangeHandler);
-  });
+  return defineElement(spec, HTMLElement, htmlElements, htmlNameToImpl);
 }
 
 function URL(attr) {
@@ -114,7 +56,7 @@ var HTMLElement = exports.HTMLElement = define({
         parser.parse(v, true);
         var tmpdoc = parser.document();
         var root = tmpdoc.firstChild;
-        var target = (this instanceof tagNameToImpl.template) ?
+        var target = (this instanceof htmlNameToImpl.template) ?
             this.content : this;
 
         // Remove any existing children of this node
@@ -266,7 +208,7 @@ define({
     type: String
   }
 });
-URLUtils._inherit(tagNameToImpl.a.prototype);
+URLUtils._inherit(htmlNameToImpl.a.prototype);
 
 define({
   tag: 'area',
@@ -1055,17 +997,17 @@ define({
 
 define({
   tag: 'audio',
-  superclass: impl.HTMLMediaElement,
+  superclass: htmlElements.HTMLMediaElement,
   ctor: function HTMLAudioElement(doc, localName, prefix) {
-    impl.HTMLMediaElement.call(this, doc, localName, prefix);
+    htmlElements.HTMLMediaElement.call(this, doc, localName, prefix);
   }
 });
 
 define({
   tag: 'video',
-  superclass: impl.HTMLMediaElement,
+  superclass: htmlElements.HTMLMediaElement,
   ctor: function HTMLVideoElement(doc, localName, prefix) {
-    impl.HTMLMediaElement.call(this, doc, localName, prefix);
+    htmlElements.HTMLMediaElement.call(this, doc, localName, prefix);
   },
   attributes: {
     poster: String,
@@ -1076,17 +1018,17 @@ define({
 
 define({
   tag: 'td',
-  superclass: impl.HTMLTableCellElement,
+  superclass: htmlElements.HTMLTableCellElement,
   ctor: function HTMLTableDataCellElement(doc, localName, prefix) {
-    impl.HTMLTableCellElement.call(this, doc, localName, prefix);
+    htmlElements.HTMLTableCellElement.call(this, doc, localName, prefix);
   }
 });
 
 define({
   tag: 'th',
-  superclass: impl.HTMLTableCellElement,
+  superclass: htmlElements.HTMLTableCellElement,
   ctor: function HTMLTableHeaderCellElement(doc, localName, prefix) {
-    impl.HTMLTableCellElement.call(this, doc, localName, prefix);
+    htmlElements.HTMLTableCellElement.call(this, doc, localName, prefix);
   },
   attributes: {
     scope: ["", "row", "col", "rowgroup", "colgroup"]

--- a/lib/impl.js
+++ b/lib/impl.js
@@ -23,3 +23,4 @@ exports = module.exports = {
 
 utils.merge(exports, require('./events'));
 utils.merge(exports, require('./htmlelts').elements);
+utils.merge(exports, require('./svg').elements);

--- a/lib/svg.js
+++ b/lib/svg.js
@@ -9,7 +9,7 @@ var svgNameToImpl = Object.create(null);
 
 exports.createElement = function(doc, localName, prefix) {
   var impl = svgNameToImpl[localName] || SVGElement;
-  return new impl(doc, localName, prefix, utils.NAMESPACE.SVG);
+  return new impl(doc, localName, prefix);
 };
 
 function define(spec) {
@@ -18,8 +18,8 @@ function define(spec) {
 
 var SVGElement = define({
   superclass: Element,
-  ctor: function SVGElement(doc, localName, prefix, namespaceURI) {
-    Element.call(this, doc, localName, namespaceURI, prefix);
+  ctor: function SVGElement(doc, localName, prefix) {
+    Element.call(this, doc, localName, utils.NAMESPACE.SVG, prefix);
   },
   props: {
     style: { get: function() {
@@ -31,13 +31,13 @@ var SVGElement = define({
 });
 
 define({
-  ctor: function SVGSVGElement(doc, localName, prefix, namespaceURI) {
-    SVGElement.call(this, doc, localName, prefix, namespaceURI);
+  ctor: function SVGSVGElement(doc, localName, prefix) {
+    SVGElement.call(this, doc, localName, prefix);
   },
   tag: 'svg',
   props: {
     createSVGRect: { value: function () {
-      return new SVGElement(this.ownerDocument, 'rect', this.prefix, this.namespaceURI);
+      return new SVGElement(this.ownerDocument, 'rect', this.prefix);
     } }
   }
 });

--- a/lib/svg.js
+++ b/lib/svg.js
@@ -37,7 +37,21 @@ define({
   tag: 'svg',
   props: {
     createSVGRect: { value: function () {
-      return new SVGElement(this.ownerDocument, 'rect', this.prefix);
+      return exports.createElement(this.ownerDocument, 'rect', null);
     } }
   }
+});
+
+define({
+  tags: [
+    'a', 'altGlyph', 'altGlyphDef', 'altGlyphItem', 'animate', 'animateColor', 'animateMotion', 'animateTransform',
+    'circle', 'clipPath', 'color-profile', 'cursor', 'defs', 'desc', 'ellipse', 'feBlend', 'feColorMatrix',
+    'feComponentTransfer', 'feComposite', 'feConvolveMatrix', 'feDiffuseLighting', 'feDisplacementMap', 'feDistantLight',
+    'feFlood', 'feFuncA', 'feFuncB', 'feFuncG', 'feFuncR', 'feGaussianBlur', 'feImage', 'feMerge', 'feMergeNode',
+    'feMorphology', 'feOffset', 'fePointLight', 'feSpecularLighting', 'feSpotLight', 'feTile', 'feTurbulence', 'filter',
+    'font', 'font-face', 'font-face-format', 'font-face-name', 'font-face-src', 'font-face-uri', 'foreignObject', 'g',
+    'glyph', 'glyphRef', 'hkern', 'image', 'line', 'linearGradient', 'marker', 'mask', 'metadata', 'missing-glyph',
+    'mpath', 'path', 'pattern', 'polygon', 'polyline', 'radialGradient', 'rect', 'script', 'set', 'stop',  'style',
+    'switch', 'symbol', 'text', 'textPath', 'title', 'tref', 'tspan', 'use', 'view', 'vkern'
+  ]
 });

--- a/lib/svg.js
+++ b/lib/svg.js
@@ -1,44 +1,24 @@
 "use strict";
 var Element = require('./Element');
-var attributes = require('./attributes');
+var defineElement = require('./defineElement');
+var utils = require('./utils');
 var CSSStyleDeclaration = require('./CSSStyleDeclaration');
 
-var impl = exports.elements = {};
-var tagNameToImpl = Object.create(null);
+var svgElements = exports.elements = {};
+var svgNameToImpl = Object.create(null);
 
-exports.createElement = function(doc, localName, namespaceURI, prefix) {
-  var elementImpl = tagNameToImpl[localName] || SVGElement;
-  return new elementImpl(doc, localName, namespaceURI, prefix);
+exports.createElement = function(doc, localName, prefix) {
+  var impl = svgNameToImpl[localName] || SVGElement;
+  return new impl(doc, localName, prefix, utils.NAMESPACE.SVG);
 };
 
 function define(spec) {
-  var c = spec.ctor;
-  if (c) {
-    var props = spec.props || {};
-    if (spec.attributes) {
-      for (var n in spec.attributes) {
-        var attr = spec.attributes[n];
-        if (typeof attr !== 'object' || Array.isArray(attr)) attr = {type: attr};
-        if (!attr.name) attr.name = n.toLowerCase();
-        props[n] = attributes.property(attr);
-      }
-    }
-    props.constructor = { value : c };
-    c.prototype = Object.create((spec.superclass || SVGElement).prototype, props);
-    impl[c.name] = c;
-  }
-  else {
-    c = SVGElement;
-  }
-  (spec.tags || spec.tag && [spec.tag] || []).forEach(function(tag) {
-    tagNameToImpl[tag] = c;
-  });
-  return c;
+  return defineElement(spec, SVGElement, svgElements, svgNameToImpl);
 }
 
-var SVGElement = exports.SVGElement = define({
+var SVGElement = define({
   superclass: Element,
-  ctor: function SVGElement(doc, localName, namespaceURI, prefix) {
+  ctor: function SVGElement(doc, localName, prefix, namespaceURI) {
     Element.call(this, doc, localName, namespaceURI, prefix);
   },
   props: {
@@ -51,13 +31,13 @@ var SVGElement = exports.SVGElement = define({
 });
 
 define({
-  ctor: function SVGSVGElement(doc, localName, namespaceURI, prefix) {
-    SVGElement.call(this, doc, localName, namespaceURI, prefix);
+  ctor: function SVGSVGElement(doc, localName, prefix, namespaceURI) {
+    SVGElement.call(this, doc, localName, prefix, namespaceURI);
   },
   tag: 'svg',
   props: {
     createSVGRect: { value: function () {
-      return new SVGElement(this.ownerDocument, 'rect', this.namespaceURI, this.prefix);
+      return new SVGElement(this.ownerDocument, 'rect', this.prefix, this.namespaceURI);
     } }
   }
 });

--- a/lib/svg.js
+++ b/lib/svg.js
@@ -1,0 +1,63 @@
+"use strict";
+var Element = require('./Element');
+var attributes = require('./attributes');
+var CSSStyleDeclaration = require('./CSSStyleDeclaration');
+
+var impl = exports.elements = {};
+var tagNameToImpl = Object.create(null);
+
+exports.createElement = function(doc, localName, namespaceURI, prefix) {
+  var elementImpl = tagNameToImpl[localName] || SVGElement;
+  return new elementImpl(doc, localName, namespaceURI, prefix);
+};
+
+function define(spec) {
+  var c = spec.ctor;
+  if (c) {
+    var props = spec.props || {};
+    if (spec.attributes) {
+      for (var n in spec.attributes) {
+        var attr = spec.attributes[n];
+        if (typeof attr !== 'object' || Array.isArray(attr)) attr = {type: attr};
+        if (!attr.name) attr.name = n.toLowerCase();
+        props[n] = attributes.property(attr);
+      }
+    }
+    props.constructor = { value : c };
+    c.prototype = Object.create((spec.superclass || SVGElement).prototype, props);
+    impl[c.name] = c;
+  }
+  else {
+    c = SVGElement;
+  }
+  (spec.tags || spec.tag && [spec.tag] || []).forEach(function(tag) {
+    tagNameToImpl[tag] = c;
+  });
+  return c;
+}
+
+var SVGElement = exports.SVGElement = define({
+  superclass: Element,
+  ctor: function SVGElement(doc, localName, namespaceURI, prefix) {
+    Element.call(this, doc, localName, namespaceURI, prefix);
+  },
+  props: {
+    style: { get: function() {
+      if (!this._style)
+        this._style = new CSSStyleDeclaration(this);
+      return this._style;
+    }}
+  }
+});
+
+define({
+  ctor: function SVGSVGElement(doc, localName, namespaceURI, prefix) {
+    SVGElement.call(this, doc, localName, namespaceURI, prefix);
+  },
+  tag: 'svg',
+  props: {
+    createSVGRect: { value: function () {
+      return new SVGElement(this.ownerDocument, 'rect', this.namespaceURI, this.prefix);
+    } }
+  }
+});

--- a/test/domino.js
+++ b/test/domino.js
@@ -792,3 +792,13 @@ exports.small_list = function() {
     smalls[i].classList.contains('foo').should.be.true();
   }
 };
+
+exports.createSvgElements = function() {
+  var document = domino.createDocument();
+
+  var svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  document.body.appendChild(svg);
+  
+  svg.should.be.instanceOf(domino.impl.SVGSVGElement);
+  document.body.innerHTML.should.equal("<svg></svg>");
+}


### PR DESCRIPTION
This PR adds SVG elements, as discussed briefly in #81. The key difference with this change is that `document.createElementNS('http://www.w3.org/2000/svg', 'svg')` now returns a real SVGSVGElement, not a plain `Element`, including a createSVGRect method. That method is the key bit for my use case because that's how Leaflet does SVG detection: https://github.com/Leaflet/Leaflet/blob/master/src/layer/vector/SVG.js#L225.

This change includes a very basic test to check that core functionality is working, and some refactoring to share the element definition code between HTML and SVG elements. That element definition is mostly as it was, but now parameterized so it can take different fallback super constructors (HTMLElement vs SVGElement), and add the resulting elements to the separate lists of HTML/SVG elements.

This is obviously only a small first step - I'm supporting only the tiny part of the spec I need to make detection work, and no more. I'm going to be taking a look at running D3 on top of Domino soon, and that's likely to require filling out the interfaces a little further, if you're game for that. It'd be nice to fill out much more of the interface to add real support in the long term, but progressively adding small parts for now seems like a good first step.

I'd quite like to add some more detailed and definitive tests, but there doesn't seem to be an obvious standard automated SVG suite. All the [web platform tests](https://github.com/w3c/web-platform-tests/tree/master/svg) are manual image rendering comparisons, which aren't really relevant. There is an [interface definition](https://github.com/w3c/web-platform-tests/blob/master/svg/interfaces.html) in there in IDL though too. Is there an easy way to turn that into a working test suite? Is there an easy way to include all those and enable them individually to progressively support this? I'm finding the layers of test harnesses here so far a little confusing to add to.