### PR TITLE
Actually run the HTMLWG tests [work in progress]

### DIFF
--- a/test/htmlwg/harness/index.js
+++ b/test/htmlwg/harness/index.js
@@ -35,13 +35,14 @@ module.exports = function(path) {
     scripts = [].slice.call(scripts);
 
     return function() {
-      window._run(`
+      function listenForFailures() {
         add_result_callback(function(result) {
           if (result.status === result.FAIL) {
             throw new Error(result.message);
           }
         });
-      `);
+      }
+      window._run("(" + listenForFailures.toString() + ")();");
 
       var concatenatedScripts = scripts.map(function(script) {
         return script.textContent;


### PR DESCRIPTION
I had a look at adding some tests to the test suite, and I noticed that the current htmlwg tests aren't actually run. If you intentionally make them fail, the suite still passes.

That's happening because the test harness actually runs only the final script tag in the test (so none of the setup ones previously), and then ignores the result. Failures inside the test are caught by the test framework, which swallows them and notifies results to test listeners, but the harness doesn't listen for those results. Unless the test throws an exception outside its `test()` call, it silently passes.

This change starts listening for those failures. ...Unfortunately though, that means it makes 2/3s of these tests fail.

I thought it's probably worth opening anyway, so you know what's up. Is there a nice way to quarantine these, so they can be progressively fixed up easily?