### PR TITLE
Make key properties writable to allow polyfilling

### DIFF
--- a/lib/Document.js
+++ b/lib/Document.js
@@ -22,6 +22,7 @@ var svg = require('./svg');
 var utils = require('./utils');
 var MUTATE = require('./MutationConstants');
 var NAMESPACE = utils.NAMESPACE;
+var isApiWritable = require("./config").isApiWritable;
 
 function Document(isHTML, address) {
   this.nodeType = Node.DOCUMENT_NODE;
@@ -135,7 +136,7 @@ Document.prototype = Object.create(Node.prototype, {
     if (!xml.isValidName(localName)) utils.InvalidCharacterError();
     if (this.isHTML) localName = utils.toASCIILowerCase(localName);
     return html.createElement(this, localName, null);
-  }, writable: true },
+  }, writable: isApiWritable },
 
   createElementNS: { value: function(namespace, qualifiedName) {
     if (!xml.isValidName(qualifiedName)) utils.InvalidCharacterError();
@@ -170,7 +171,7 @@ Document.prototype = Object.create(Node.prototype, {
     }
 
     return new Element(this, localName, namespace, prefix);
-  }, writable: true },
+  }, writable: isApiWritable },
 
   createEvent: { value: function createEvent(interfaceName) {
     interfaceName = interfaceName.toLowerCase();
@@ -346,7 +347,7 @@ Document.prototype = Object.create(Node.prototype, {
 
   importNode: { value: function importNode(node, deep) {
     return this.adoptNode(node.cloneNode());
-  }, writable: true },
+  }, writable: isApiWritable },
 
   // The following attributes and methods are from the HTML spec
   URL: { get: utils.nyi },

--- a/lib/Document.js
+++ b/lib/Document.js
@@ -135,7 +135,7 @@ Document.prototype = Object.create(Node.prototype, {
     if (!xml.isValidName(localName)) utils.InvalidCharacterError();
     if (this.isHTML) localName = utils.toASCIILowerCase(localName);
     return html.createElement(this, localName, null);
-  }},
+  }, writable: true },
 
   createElementNS: { value: function(namespace, qualifiedName) {
     if (!xml.isValidName(qualifiedName)) utils.InvalidCharacterError();
@@ -170,7 +170,7 @@ Document.prototype = Object.create(Node.prototype, {
     }
 
     return new Element(this, localName, namespace, prefix);
-  }},
+  }, writable: true },
 
   createEvent: { value: function createEvent(interfaceName) {
     interfaceName = interfaceName.toLowerCase();
@@ -346,7 +346,7 @@ Document.prototype = Object.create(Node.prototype, {
 
   importNode: { value: function importNode(node, deep) {
     return this.adoptNode(node.cloneNode());
-  }},
+  }, writable: true },
 
   // The following attributes and methods are from the HTML spec
   URL: { get: utils.nyi },

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,7 @@
+/* 
+ * This file defines Domino behaviour that can be externally configured.
+ * To change these settings, set the relevant global property *before*
+ * you call require("domino").
+ */
+
+exports.isApiWritable = global.__domino_writable__ || true;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -48,7 +48,7 @@ exports.assert = function(expr, msg) {
 
 exports.expose = function(src, c) {
   for (var n in src) {
-    Object.defineProperty(c.prototype, n, {value: src[n] });
+    Object.defineProperty(c.prototype, n, { value: src[n], writable: true });
   }
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,7 @@
 "use strict";
 var DOMException = require('./DOMException');
 var ERR = DOMException;
+var isApiWritable = require("./config").isApiWritable;
 
 exports.NAMESPACE = {
   HTML: 'http://www.w3.org/1999/xhtml',
@@ -48,7 +49,7 @@ exports.assert = function(expr, msg) {
 
 exports.expose = function(src, c) {
   for (var n in src) {
-    Object.defineProperty(c.prototype, n, { value: src[n], writable: true });
+    Object.defineProperty(c.prototype, n, { value: src[n], writable: isApiWritable });
   }
 };
 

--- a/test/domino.js
+++ b/test/domino.js
@@ -852,3 +852,19 @@ exports.createSvgElements = function() {
   svg.should.be.instanceOf(domino.impl.SVGSVGElement);
   document.body.innerHTML.should.equal("<svg></svg>");
 }
+
+exports.propertyWritability = function () {
+  var window = domino.createWindow('');
+  var document = domino.createDocument();
+
+  function assertWritable(object, property) {
+    var replacement = function () { };
+    object[property] = replacement;
+    object[property].should.equal(replacement, property + " should be writable");
+  }
+
+  assertWritable(window, 'HTMLElement');
+  assertWritable(document, 'importNode');
+  assertWritable(document, 'createElement');
+  assertWritable(document, 'createElementNS');
+}


### PR DESCRIPTION
Many polyfills rewrite built-ins on the DOM to add new functionality and support new upcoming specs. In the browser, this is fine - DOM properties are reliably writable everywhere. In Domino they aren't.

The specific changes here are to support the standard custom-elements polyfill https://github.com/webcomponents/custom-elements/blob/master/src/custom-elements.js, which is currently unusable with Domino, but this does cover the most popular and widely applicable methods generally.

This should probably be extended in future to cover the whole API, making it consistent with browsers, and allowing any polyfill to run as well here as it does elsewhere. For now though I'm opening this to start the discussion, since it's a simple fix that solves my issues.

In the custom elements case, there is an argument that this should just become an actual part of Domino (and I'd suggest considering that in the future, as the standard gets adopted). That's a big job for now though, and this will happen with other polyfills in future anyway.