### PR TITLE
Fix #90: harmonize hasAttribute and removeAttribute expectations.

### DIFF
--- a/lib/Element.js
+++ b/lib/Element.js
@@ -509,7 +509,7 @@ Element.prototype = Object.create(Node.prototype, {
     }
     else {
       // only a single match, so remove the qname mapping
-      this._attrsByQName[qname] = undefined;
+      delete this._attrsByQName[qname];
     }
 
     var ns = attr.namespaceURI;
@@ -537,7 +537,7 @@ Element.prototype = Object.create(Node.prototype, {
     var attr = this._attrsByLName[key];
     if (!attr) return;
 
-    this._attrsByLName[key] = undefined;
+    delete this._attrsByLName[key];
 
     var i = this._attrKeys.indexOf(key);
     this._attrKeys.splice(i, 1);

--- a/test/domino.js
+++ b/test/domino.js
@@ -852,3 +852,20 @@ exports.createSvgElements = function() {
   svg.should.be.instanceOf(domino.impl.SVGSVGElement);
   document.body.innerHTML.should.equal("<svg></svg>");
 }
+
+exports.gh90 = function() {
+  var doc = '<input type="checkbox">';
+  var document = domino.createDocument(doc);
+  document.body.innerHTML.should.equal(doc);
+
+  var input = document.querySelector('input');
+  input.checked.should.equal(false)
+
+  input.checked = true
+  input.checked.should.equal(true)
+  input.outerHTML.should.equal('<input type="checkbox" checked="">')
+
+  input.checked = false
+  input.checked.should.equal(false)
+  input.outerHTML.should.equal(doc)
+};


### PR DESCRIPTION
hasAttribute checks for properties via `in this._attrsByQName` which
will check if the property exists in the object at all. But
removeAttribute clears the property via
`this._attrsByQName[qname] = undefined` which doesn't clear the property
as far as the `in` operator is concerned.

So, use the `delete` operator instead.