### PR TITLE
Add the web-platform-tests/dom/nodes tests

### DIFF
--- a/test/web-platform-tests.js
+++ b/test/web-platform-tests.js
@@ -6,6 +6,7 @@ var domino = require('../lib');
 // These are the tests we currently fail.
 // Some of these failures are bugs we ought to fix.
 var blacklist = [
+  // web-platform-tests/html/dom
   'interfaces',
   'documents dom-tree-accessors Document.body',
   'documents dom-tree-accessors Document.currentScript.sub',
@@ -68,6 +69,113 @@ var blacklist = [
   'elements global-attributes the-translate-attribute-010',
   'elements global-attributes the-translate-attribute-011',
   'elements global-attributes the-translate-attribute-012',
+  
+  // web-platform-tests/dom/nodes
+  'CharacterData-appendChild',
+  'CharacterData-appendData',
+  'CharacterData-data',
+  'CharacterData-deleteData',
+  'CharacterData-insertData',
+  'CharacterData-remove',
+  'CharacterData-replaceData',
+  'CharacterData-substringData',
+  'ChildNode-after',
+  'ChildNode-before',
+  'ChildNode-replaceWith',
+  'Comment-constructor',
+  'DOMImplementation-createDocument',
+  'DOMImplementation-createDocumentType',
+  'DOMImplementation-createHTMLDocument',
+  'DOMImplementation-hasFeature',
+  'Document-URL.sub',
+  'Document-adoptNode',
+  'Document-characterSet-normalization',
+  'Document-constructor',
+  /Document-contentType/,
+  'Document-createAttribute',
+  'Document-createComment',
+  'Document-createElement-namespace',
+  'Document-createElement',
+  'Document-createElementNS',
+  'Document-createEvent',
+  'Document-createProcessingInstruction',
+  'Document-createTextNode',
+  'Document-createTreeWalker',
+  'Document-getElementById',
+  'Document-getElementsByTagName',
+  'Document-getElementsByTagName-xhtml',
+  'Document-getElementsByTagNameNS',
+  'Document-importNode',
+  'DocumentType-remove',
+  'Element-childElement-null-xhtml',
+  'Element-childElementCount-dynamic-add-xhtml',
+  'Element-childElementCount-dynamic-remove-xhtml',
+  'Element-childElementCount-nochild-xhtml',
+  'Element-childElementCount-xhtml',
+  'Element-children',
+  'Element-classlist',
+  'Element-closest',
+  'Element-firstElementChild-entity-xhtml',
+  'Element-firstElementChild-xhtml',
+  'Element-firstElementChild-namespace-xhtml',
+  'Element-getElementsByClassName',
+  'Element-getElementsByTagName-change-document-HTMLNess',
+  'Element-getElementsByTagName',
+  'Element-getElementsByTagNameNS',
+  'Element-hasAttributes',
+  'Element-insertAdjacentElement',
+  'Element-insertAdjacentText',
+  'Element-lastElementChild-xhtml',
+  'Element-matches',
+  'Element-nextElementSibling-xhtml',
+  'Element-previousElementSibling-xhtml',
+  'Element-remove',
+  'Element-removeAttributeNS',
+  'Element-siblingElement-null-xhtml',
+  'Element-tagName',
+  'MutationObserver-attributes',
+  'MutationObserver-characterData',
+  'MutationObserver-childList',
+  'MutationObserver-disconnect',
+  'MutationObserver-document',
+  'MutationObserver-inner-outer',
+  'MutationObserver-takeRecords',
+  'Node-appendChild',
+  'Node-baseURI',
+  'Node-childNodes',
+  'Node-cloneNode',
+  'Node-compareDocumentPosition',
+  'Node-constants',
+  'Node-contains',
+  'Node-insertBefore',
+  'Node-isConnected',
+  'Node-isEqualNode',
+  'Node-isEqualNode-xhtml',
+  'Node-isSameNode',
+  'Node-lookupPrefix',
+  'Node-lookupNamespaceURI',
+  'Node-nodeName-xhtml',
+  'Node-nodeValue',
+  'Node-parentNode-iframe',
+  'Node-parentNode',
+  'Node-properties',
+  'Node-removeChild',
+  'Node-replaceChild',
+  'Node-textContent',
+  'NodeList-Iterable',
+  'ParentNode-append',
+  'ParentNode-prepend',
+  'ParentNode-querySelector-All-content',
+  'ParentNode-querySelector-All',
+  /ProcessingInstruction/,
+  'Text-constructor',
+  'append-on-Document',
+  'attributes',
+  'case',
+  'insert-adjacent',
+  'prepend-on-Document',
+  'remove-unscopable',
+  'rootNode',
 ].map(function(s) {
   // Convert strings to equivalent regular expression matchers.
   if (typeof s === 'string') {
@@ -108,59 +216,63 @@ function list(base, dir, fn) {
   return result;
 }
 
-var harness = function(path) {
-  return list(path, '', function(name, file) {
-    var html = read(file);
-    var window = domino.createWindow(html);
-    window._run(testharness);
-    var scripts = window.document.getElementsByTagName('script');
-    scripts = [].slice.call(scripts);
+var harness = function() {
+  var paths = [].slice.call(arguments);
+  return paths.map(function (path) {
+    return list(path, '', function(name, file) {
+      var html = read(file);
+      var window = domino.createWindow(html);
+      window._run(testharness);
+      var scripts = window.document.getElementsByTagName('script');
+      scripts = [].slice.call(scripts);
 
-    return function() {
-      var listen = onBlacklist(name) ? function listenForSuccess() {
-        add_completion_callback(function(tests, status) {
-          var failed = tests.filter(function(t) {
-            return t.status === t.FAIL || t.status === t.TIMEOUT;
+      return function() {
+        var listen = onBlacklist(name) ? function listenForSuccess() {
+          add_completion_callback(function(tests, status) {
+            var failed = tests.filter(function(t) {
+              return t.status === t.FAIL || t.status === t.TIMEOUT;
+            });
+            if (failed.length===0) {
+              throw new Error("Expected blacklisted test to fail");
+            }
           });
-          if (failed.length===0) {
-            throw new Error("Expected blacklisted test to fail");
-          }
-        });
-      } : function listenForFailures() {
-        add_completion_callback(function(tests, status) {
-          var failed = tests.filter(function(t) {
-            return t.status === t.FAIL || t.status === t.TIMEOUT;
+        } : function listenForFailures() {
+          add_completion_callback(function(tests, status) {
+            var failed = tests.filter(function(t) {
+              return t.status === t.FAIL || t.status === t.TIMEOUT;
+            });
+            if (failed.length) {
+              throw new Error(failed[0].name+": "+failed[0].message);
+            }
           });
-          if (failed.length) {
-            throw new Error(failed[0].name+": "+failed[0].message);
+        };
+        window._run("(" + listen.toString() + ")();");
+
+        var concatenatedScripts = scripts.map(function(script) {
+          if (/^text\/plain$/.test(script.getAttribute('type')||'')) {
+            return '';
           }
-        });
-      };
-      window._run("(" + listen.toString() + ")();");
+          return script.textContent + '\n';
+        }).join("\n");
+        // Workaround for https://github.com/w3c/web-platform-tests/pull/3984
+        concatenatedScripts = 'var x;\n' + concatenatedScripts;
+        concatenatedScripts += '\nwindow.dispatchEvent(new Event("load"));';
 
-      var concatenatedScripts = scripts.map(function(script) {
-        if (/^text\/plain$/.test(script.getAttribute('type')||'')) {
-          return '';
+        var go = function() {
+          window._run(concatenatedScripts);
+        };
+        try {
+          go();
+        } catch (e) {
+          if ((!onBlacklist(name)) ||
+              /^Expected blacklisted test to fail/.test(e.message||'')) {
+            throw e;
+          }
         }
-        return script.textContent + '\n';
-      }).join("\n");
-      // Workaround for https://github.com/w3c/web-platform-tests/pull/3984
-      concatenatedScripts = 'var x;\n' + concatenatedScripts;
-      concatenatedScripts += '\nwindow.dispatchEvent(new Event("load"));';
-
-      var go = function() {
-        window._run(concatenatedScripts);
       };
-      try {
-        go();
-      } catch (e) {
-        if ((!onBlacklist(name)) ||
-            /^Expected blacklisted test to fail/.test(e.message||'')) {
-          throw e;
-        }
-      }
-    };
+    })
   });
 };
 
-module.exports = harness(__dirname + '/web-platform-tests/html/dom');
+module.exports = harness(__dirname + '/web-platform-tests/html/dom',
+                         __dirname + '/web-platform-tests/dom/nodes');


### PR DESCRIPTION
First part of starting work on #80 is getting the rest of the relevant suite pulled in, so I can turn the mutation observer tests on. This PR does that: enabling all the /dom/nodes tests in web-platform-tests, but blacklisting those that don't currently pass (quite a few). This adds 40 new passing tests and 123 new blacklisted ones in total.

The build is failing, but not the new tests - it's the same unrelated Node 7 issue as #89.