### PR TITLE
WIP: experimental linked list backing for DOM

### DIFF
--- a/lib/CharacterData.js
+++ b/lib/CharacterData.js
@@ -7,6 +7,7 @@ var ChildNode = require('./ChildNode');
 var NonDocumentTypeChildNode = require('./NonDocumentTypeChildNode');
 
 function CharacterData() {
+  Leaf.call(this);
 }
 
 CharacterData.prototype = Object.create(Leaf.prototype, {

--- a/lib/ChildNode.js
+++ b/lib/ChildNode.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var Node = require('./Node');
+var LinkedList = require('./LinkedList');
 
 var createDocumentFragmentFromArguments = function(document, args) {
   var docFrag = document.createDocumentFragment();
@@ -64,13 +65,29 @@ var ChildNode = {
     if (this.rooted && this.doc) this.doc.mutateRemove(this);
 
     // Remove this node from its parents array of children
-    this.parentNode.childNodes.splice(this.index, 1);
-
-    // Update the structure id for all ancestors
-    this.parentNode.modify();
+    // and update the structure id for all ancestors
+    this._remove();
 
     // Forget this node's parent
     this.parentNode = null;
+  }},
+
+  // Remove this node w/o uprooting or sending mutation events
+  // (But do update the structure id for all ancestors)
+  _remove: { value: function _remove() {
+    var parent = this.parentNode;
+    if (parent === null) return;
+    if (parent._childNodes) {
+      parent._childNodes.splice(this.index, 1);
+    } else if (parent._firstChild === this) {
+      if (this._nextSibling === this) {
+        parent._firstChild = null;
+      } else {
+        parent._firstChild = this._nextSibling;
+      }
+    }
+    LinkedList.remove(this);
+    parent.modify();
   }},
 
   // Replace this node with the nodes or strings provided as arguments.

--- a/lib/Comment.js
+++ b/lib/Comment.js
@@ -5,10 +5,10 @@ var Node = require('./Node');
 var CharacterData = require('./CharacterData');
 
 function Comment(doc, data) {
+  CharacterData.call(this);
   this.nodeType = Node.COMMENT_NODE;
   this.ownerDocument = doc;
   this._data = data;
-  this._index = undefined;
 }
 
 var nodeValue = {

--- a/lib/ContainerNode.js
+++ b/lib/ContainerNode.js
@@ -1,0 +1,75 @@
+"use strict";
+module.exports = ContainerNode;
+
+var Node = require('./Node');
+var NodeList = require('./NodeList');
+
+// This class defines common functionality for node subtypes that
+// can have children
+
+function ContainerNode() {
+  Node.call(this);
+  this._firstChild = this._childNodes = null;
+}
+
+// Primary representation is a circular linked list of siblings
+ContainerNode.prototype = Object.create(Node.prototype, {
+
+  hasChildNodes: { value: function() {
+    if (this._childNodes) {
+      return this._childNodes.length > 0;
+    }
+    return this._firstChild !== null;
+  }},
+
+  childNodes: { get: function() {
+    this._ensureChildNodes();
+    return this._childNodes;
+  }},
+
+  firstChild: { get: function() {
+    if (this._childNodes) {
+      return this._childNodes.length === 0 ? null : this._childNodes[0];
+    }
+    return this._firstChild;
+  }},
+
+  lastChild: { get: function() {
+    var kids = this._childNodes, first;
+    if (kids) {
+      return kids.length === 0 ? null: kids[kids.length-1];
+    }
+    first = this._firstChild;
+    if (first === null) { return null; }
+    return first._previousSibling; // circular linked list
+  }},
+
+  _ensureChildNodes: { value: function() {
+    if (this._childNodes) { return; }
+    var first = this._firstChild,
+        kid = first,
+        childNodes = this._childNodes = new NodeList();
+    if (first) do {
+      childNodes.push(kid);
+      kid = kid._nextSibling;
+    } while (kid !== first); // circular linked list
+    this._firstChild = null; // free memory
+  }},
+
+  // Remove all of this node's children.  This is a minor
+  // optimization that only calls modify() once.
+  removeChildren: { value: function removeChildren() {
+    var root = this.rooted ? this.ownerDocument : null;
+    for (var kid = this.firstChild; kid !== null; kid = kid.nextSibling) {
+      if (root) root.mutateRemove(kid);
+      kid.parentNode = null;
+    }
+    if (this._childNodes) {
+      this._childNodes.length = 0;
+    } else {
+      this._firstChild = null;
+    }
+    this.modify(); // Update last modified type once only
+  }},
+
+});

--- a/lib/Document.js
+++ b/lib/Document.js
@@ -3,6 +3,7 @@ module.exports = Document;
 
 var Node = require('./Node');
 var NodeList = require('./NodeList');
+var ContainerNode = require('./ContainerNode');
 var Element = require('./Element');
 var Text = require('./Text');
 var Comment = require('./Comment');
@@ -25,6 +26,7 @@ var NAMESPACE = utils.NAMESPACE;
 var isApiWritable = require("./config").isApiWritable;
 
 function Document(isHTML, address) {
+  ContainerNode.call(this);
   this.nodeType = Node.DOCUMENT_NODE;
   this.isHTML = isHTML;
   this._address = address || 'about:blank';
@@ -40,7 +42,6 @@ function Document(isHTML, address) {
   // XXX: override those methods!
   this.doctype = null;
   this.documentElement = null;
-  this.childNodes = new NodeList();
 
   // "Associated inert template document"
   this._templateDocCache = null;
@@ -97,7 +98,7 @@ var mirrorAttr = function(f, name, defaultValue) {
   };
 };
 
-Document.prototype = Object.create(Node.prototype, {
+Document.prototype = Object.create(ContainerNode.prototype, {
   // This method allows dom.js to communicate with a renderer
   // that displays the document in some way
   // XXX: I should probably move this to the window object
@@ -128,7 +129,6 @@ Document.prototype = Object.create(Node.prototype, {
     // The _quirks property is set by the HTML parser
     return this._quirks ? 'BackCompat' : 'CSS1Compat';
   }},
-  parentNode: { value: null },
 
   createTextNode: { value: function(data) {
     return new Text(this, '' + data);
@@ -239,14 +239,12 @@ Document.prototype = Object.create(Node.prototype, {
   // to do the actual inserting, removal or replacement.
 
   _updateDocTypeElement: { value: function _updateDocTypeElement() {
-    var i, n, nodes = this.childNodes, length = nodes.length;
     this.doctype = this.documentElement = null;
-    for (i=0; i<length; i++) {
-      n = nodes[i];
-      if (n.nodeType === Node.DOCUMENT_TYPE_NODE)
-        this.doctype = n;
-      else if (n.nodeType === Node.ELEMENT_NODE)
-        this.documentElement = n;
+    for (var kid = this.firstChild; kid !== null; kid = kid.nextSibling) {
+      if (kid.nodeType === Node.DOCUMENT_TYPE_NODE)
+        this.doctype = kid;
+      else if (kid.nodeType === Node.ELEMENT_NODE)
+        this.documentElement = kid;
     }
   }},
 
@@ -670,12 +668,11 @@ eventHandlerTypes.forEach(function(type) {
 
 function namedHTMLChild(parent, name) {
   if (parent && parent.isHTML) {
-    var kids = parent.childNodes;
-    for(var i = 0, n = kids.length; i < n; i++) {
-      if (kids[i].nodeType === Node.ELEMENT_NODE &&
-        kids[i].localName === name &&
-        kids[i].namespaceURI === NAMESPACE.HTML) {
-        return kids[i];
+    for (var kid = parent.firstChild; kid !== null; kid = kid.nextSibling) {
+      if (kid.nodeType === Node.ELEMENT_NODE &&
+        kid.localName === name &&
+        kid.namespaceURI === NAMESPACE.HTML) {
+        return kid;
       }
     }
   }
@@ -721,24 +718,22 @@ function recursivelyRoot(node) {
   }
 */
   if (node.nodeType === Node.ELEMENT_NODE) {
-    var kids = node.childNodes;
-    for(var i = 0, n = kids.length; i < n; i++)
-      recursivelyRoot(kids[i]);
+    for (var kid = node.firstChild; kid !== null; kid = kid.nextSibling)
+      recursivelyRoot(kid);
   }
 }
 
 function recursivelyUproot(node) {
   uproot(node);
-  for(var i = 0, n = node.childNodes.length; i < n; i++)
-    recursivelyUproot(node.childNodes[i]);
+  for (var kid = node.firstChild; kid !== null; kid = kid.nextSibling)
+      recursivelyUproot(kid);
 }
 
 function recursivelySetOwner(node, owner) {
   node.ownerDocument = owner;
   node._lastModTime = undefined; // mod times are document-based
-  var kids = node.childNodes;
-  for(var i = 0, n = kids.length; i < n; i++)
-    recursivelySetOwner(kids[i], owner);
+  for (var kid = node.firstChild; kid !== null; kid = kid.nextSibling)
+    recursivelySetOwner(kid, owner);
 }
 
 // A class for storing multiple nodes with the same ID

--- a/lib/DocumentFragment.js
+++ b/lib/DocumentFragment.js
@@ -3,17 +3,18 @@ module.exports =  DocumentFragment;
 
 var Node = require('./Node');
 var NodeList = require('./NodeList');
+var ContainerNode = require('./ContainerNode');
 var Element = require('./Element');
 var select = require('./select');
 var utils = require('./utils');
 
 function DocumentFragment(doc) {
+  ContainerNode.call(this);
   this.nodeType = Node.DOCUMENT_FRAGMENT_NODE;
   this.ownerDocument = doc;
-  this.childNodes = [];
 }
 
-DocumentFragment.prototype = Object.create(Node.prototype, {
+DocumentFragment.prototype = Object.create(ContainerNode.prototype, {
   nodeName: { value: '#document-fragment' },
   nodeValue: { 
     get: function() { 

--- a/lib/DocumentType.js
+++ b/lib/DocumentType.js
@@ -7,6 +7,7 @@ var utils = require('./utils');
 var ChildNode = require('./ChildNode');
 
 function DocumentType(name, publicId, systemId) {
+  Leaf.call(this);
   // Unlike other nodes, doctype nodes always start off unowned
   // until inserted
   this.nodeType = Node.DOCUMENT_TYPE_NODE;

--- a/lib/Element.js
+++ b/lib/Element.js
@@ -10,10 +10,12 @@ var NodeList = require('./NodeList');
 var FilteredElementList = require('./FilteredElementList');
 var DOMTokenList = require('./DOMTokenList');
 var select = require('./select');
+var ContainerNode = require('./ContainerNode');
 var ChildNode = require('./ChildNode');
 var NonDocumentTypeChildNode = require('./NonDocumentTypeChildNode');
 
 function Element(doc, localName, namespaceURI, prefix) {
+  ContainerNode.call(this);
   this.nodeType = Node.ELEMENT_NODE;
   this.ownerDocument = doc;
   this.localName = localName;
@@ -26,14 +28,10 @@ function Element(doc, localName, namespaceURI, prefix) {
 
   if (this.isHTML) this.tagName = this.tagName.toUpperCase();
 
-  this.childNodes = new NodeList();
-
   // These properties maintain the set of attributes
   this._attrsByQName = Object.create(null); // The qname->Attr map
   this._attrsByLName = Object.create(null); // The ns|lname->Attr map
   this._attrKeys = [];     // attr index -> ns|lname
-
-  this._index = undefined;
 }
 
 function recursiveGetText(node, a) {
@@ -46,7 +44,7 @@ function recursiveGetText(node, a) {
   }
 }
 
-Element.prototype = Object.create(Node.prototype, {
+Element.prototype = Object.create(ContainerNode.prototype, {
   nodeName: { get: function() { return this.tagName; }},
   nodeValue: {
     get: function() {
@@ -78,11 +76,7 @@ Element.prototype = Object.create(Node.prototype, {
       // "the attribute must return the result of running the HTML fragment
       // serialization algorithm on a fictional node whose only child is
       // the context object"
-      var fictional = {
-        childNodes: [ this ],
-        nodeType: 0
-      };
-      return Node.prototype.serialize.call(fictional);
+      return this._serializeOne({ nodeType: 0 });
     },
     set: utils.nyi
   },
@@ -103,17 +97,15 @@ Element.prototype = Object.create(Node.prototype, {
 
 
   firstElementChild: { get: function() {
-    var kids = this.childNodes;
-    for(var i = 0, n = kids.length; i < n; i++) {
-      if (kids[i].nodeType === Node.ELEMENT_NODE) return kids[i];
+    for (var kid = this.firstChild; kid !== null; kid = kid.nextSibling) {
+      if (kid.nodeType === Node.ELEMENT_NODE) return kid;
     }
     return null;
   }},
 
   lastElementChild: { get: function() {
-    var kids = this.childNodes;
-    for(var i = kids.length-1; i >= 0; i--) {
-      if (kids[i].nodeType === Node.ELEMENT_NODE) return kids[i];
+    for (var kid = this.lastChild; kid !== null; kid = kid.previousSibling) {
+      if (kid.nodeType === Node.ELEMENT_NODE) return kid;
     }
     return null;
   }},
@@ -824,8 +816,7 @@ ChildrenCollection.prototype = {
       this.childrenByNumber = [];
       this.childrenByName = Object.create(null);
 
-      for(i = 0, n = this.element.childNodes.length; i < n; i++) {
-        var c = this.element.childNodes[i];
+      for (var c = this.element.firstChild; c !== null; c = c.nextSibling) {
         if (c.nodeType === Node.ELEMENT_NODE) {
 
           this[this.childrenByNumber.length] = c;

--- a/lib/Leaf.js
+++ b/lib/Leaf.js
@@ -2,6 +2,7 @@
 module.exports = Leaf;
 
 var Node = require('./Node');
+var NodeList = require('./NodeList');
 var utils = require('./utils');
 var HierarchyRequestError = utils.HierarchyRequestError;
 var NotFoundError = utils.NotFoundError;
@@ -9,6 +10,7 @@ var NotFoundError = utils.NotFoundError;
 // This class defines common functionality for node subtypes that
 // can never have children
 function Leaf() {
+  Node.call(this);
 }
 
 Leaf.prototype = Object.create(Node.prototype, {
@@ -27,8 +29,9 @@ Leaf.prototype = Object.create(Node.prototype, {
     if (!node.nodeType) throw new TypeError('not a node');
     NotFoundError();
   }},
+  removeChildren: { value: function() { /* no op */ }},
   childNodes: { get: function() {
-    if (!this._childNodes) this._childNodes = [];
+    if (!this._childNodes) this._childNodes = new NodeList();
     return this._childNodes;
   }}
 });

--- a/lib/LinkedList.js
+++ b/lib/LinkedList.js
@@ -1,0 +1,44 @@
+"use strict";
+var utils = require('./utils');
+
+var LinkedList = module.exports = {
+    // basic validity tests on a circular linked list a
+    valid: function(a) {
+        utils.assert(a, "list falsy");
+        utils.assert(a._previousSibling, "previous falsy");
+        utils.assert(a._nextSibling, "next falsy");
+        // xxx check that list is actually circular
+        return true;
+    },
+    // insert a before b
+    insertBefore: function(a, b) {
+        utils.assert(LinkedList.valid(a) && LinkedList.valid(b));
+        var a_first = a, a_last = a._previousSibling;
+        var b_first = b, b_last = b._previousSibling;
+        a_first._previousSibling = b_last;
+        a_last._nextSibling = b_first;
+        b_last._nextSibling = a_first;
+        b_first._previousSibling = a_last;
+        utils.assert(LinkedList.valid(a) && LinkedList.valid(b));
+    },
+    // replace a single node a with a list b (which could be null)
+    replace: function(a, b) {
+        utils.assert(LinkedList.valid(a) && (b===null || LinkedList.valid(b)));
+        if (b!==null) {
+            LinkedList.insertBefore(b, a);
+        }
+        LinkedList.remove(a);
+        utils.assert(LinkedList.valid(a) && (b===null || LinkedList.valid(b)));
+    },
+    // remove single node a from its list
+    remove: function(a) {
+        utils.assert(LinkedList.valid(a));
+        var prev = a._previousSibling;
+        if (prev === a) { return; }
+        var next = a._nextSibling;
+        prev._nextSibling = next;
+        next._previousSibling = prev;
+        a._previousSibling = a._nextSibling = a;
+        utils.assert(LinkedList.valid(a));
+    }
+};

--- a/lib/Node.js
+++ b/lib/Node.js
@@ -2,6 +2,7 @@
 module.exports = Node;
 
 var EventTarget = require('./EventTarget');
+var LinkedList = require('./LinkedList');
 var utils = require('./utils');
 var NAMESPACE = utils.NAMESPACE;
 
@@ -11,6 +12,10 @@ var NAMESPACE = utils.NAMESPACE;
 // of a subtype, so all the properties are defined by more specific
 // constructors.
 function Node() {
+  EventTarget.call(this);
+  this.parentNode = null;
+  this._nextSibling = this._previousSibling = this;
+  this._index = undefined;
 }
 
 var ELEMENT_NODE                = Node.ELEMENT_NODE = 1;
@@ -75,7 +80,6 @@ var extraNewLine = {
 Node.prototype = Object.create(EventTarget.prototype, {
 
   // Node that are not inserted into the tree inherit a null parent
-  parentNode: { value: null, writable: true },
 
   // XXX: the baseURI attribute is defined by dom core, but
   // a correct implementation of it requires HTML features, so
@@ -86,41 +90,37 @@ Node.prototype = Object.create(EventTarget.prototype, {
     return (this.parentNode && this.parentNode.nodeType===ELEMENT_NODE) ? this.parentNode : null;
   }},
 
-  hasChildNodes: { value: function() {  // Overridden in leaf.js
-    return this.childNodes.length > 0;
-  }},
+  hasChildNodes: { value: utils.shouldOverride },
 
-  firstChild: { get: function() {
-    return this.childNodes.length === 0 ? null : this.childNodes[0];
-  }},
+  firstChild: { get: utils.shouldOverride },
 
-  lastChild: { get: function() {
-    return this.childNodes.length === 0 ? null : this.childNodes[this.childNodes.length-1];
-  }},
+  lastChild: { get: utils.shouldOverride },
 
   previousSibling: { get: function() {
-    if (!this.parentNode) return null;
-    var sibs = this.parentNode.childNodes, i = this.index;
-    return i === 0 ? null : sibs[i-1];
+    var parent = this.parentNode;
+    if (!parent) return null;
+    if (this === parent.firstChild) return null;
+    return this._previousSibling;
   }},
 
   nextSibling: { get: function() {
-    if (!this.parentNode) return null;
-    var sibs = this.parentNode.childNodes, i = this.index;
-    return i+1 === sibs.length ? null : sibs[i+1];
+    var parent = this.parentNode, next = this._nextSibling;
+    if (!parent) return null;
+    if (next === parent.firstChild) return null;
+    return next;
   }},
 
 
   _countChildrenOfType: { value: function(type) {
-    var sum = 0, nodes = this.childNodes, length = nodes.length, i;
-    for (i=0; i<length; i++) {
-      if (nodes[i].nodeType === type) sum++;
+    var sum = 0;
+    for (var kid = this.firstChild; kid !== null; kid = kid.nextSibling) {
+      if (kid.nodeType === type) sum++;
     }
     return sum;
   }},
 
   _ensureInsertValid: { value: function _ensureInsertValid(node, child, isPreinsert) {
-    var parent = this, i;
+    var parent = this, i, kid;
     if (!node.nodeType) throw new TypeError('not a node');
     // 1. If parent is not a Document, DocumentFragment, or Element
     // node, throw a HierarchyRequestError.
@@ -181,9 +181,8 @@ Node.prototype = Object.create(EventTarget.prototype, {
           if (child !== null /* always true here for replaceWith */) {
             if (isPreinsert && child.nodeType === DOCUMENT_TYPE_NODE)
               utils.HierarchyRequestError();
-            for (i=parent.childNodes.length-1; i>=0; i--) {
-              if (parent.childNodes[i] === child) break;
-              if (parent.childNodes[i].nodeType === DOCUMENT_TYPE_NODE)
+            for (kid = child.nextSibling; kid !== null; kid = kid.nextSibling) {
+              if (kid.nodeType === DOCUMENT_TYPE_NODE)
                 utils.HierarchyRequestError();
             }
           }
@@ -210,9 +209,8 @@ Node.prototype = Object.create(EventTarget.prototype, {
         if (child !== null /* always true here for replaceWith */) {
           if (isPreinsert && child.nodeType === DOCUMENT_TYPE_NODE)
             utils.HierarchyRequestError();
-          for (i=parent.childNodes.length-1; i>=0; i--) {
-            if (parent.childNodes[i] === child) break;
-            if (parent.childNodes[i].nodeType === DOCUMENT_TYPE_NODE)
+          for (kid = child.nextSibling; kid !== null; kid = kid.nextSibling) {
+            if (kid.nodeType === DOCUMENT_TYPE_NODE)
               utils.HierarchyRequestError();
           }
         }
@@ -238,9 +236,9 @@ Node.prototype = Object.create(EventTarget.prototype, {
             utils.HierarchyRequestError();
         } else {
           // child is always non-null for [replaceWith] case
-          for (i=0; i<parent.childNodes.length; i++) {
-            if (parent.childNodes[i] === child) break;
-            if (parent.childNodes[i].nodeType === ELEMENT_NODE)
+          for (kid = parent.firstChild; kid !== null; kid = kid.nextSibling) {
+            if (kid === child) break;
+            if (kid.nodeType === ELEMENT_NODE)
               utils.HierarchyRequestError();
           }
         }
@@ -273,11 +271,7 @@ Node.prototype = Object.create(EventTarget.prototype, {
     // 4. Adopt node into parent's node document.
     parent.doc.adoptNode(node);
     // 5. Insert node into parent before reference child.
-    if (refChild === null) {
-      parent._appendChild(node);
-    } else {
-      node.insert(parent, refChild.index);
-    }
+    node._insertOrReplace(parent, refChild, false);
     // 6. Return node
     return node;
   }},
@@ -289,8 +283,7 @@ Node.prototype = Object.create(EventTarget.prototype, {
   }},
 
   _appendChild: { value: function(child) {
-    child.insert(this, this.childNodes.length);
-    return child;
+    child._insertOrReplace(this, null, false);
   }},
 
   removeChild: { value: function removeChild(child) {
@@ -317,7 +310,7 @@ Node.prototype = Object.create(EventTarget.prototype, {
       parent.doc.adoptNode(node);
     }
     // Do the replace.
-    node._insertOrReplace(parent, child.index, true);
+    node._insertOrReplace(parent, child, true);
     return child;
   }},
 
@@ -393,29 +386,16 @@ Node.prototype = Object.create(EventTarget.prototype, {
     if (!node) return false;
     if (node.nodeType !== this.nodeType) return false;
 
-    // Check for same number of children
-    // Check for children this way because it is more efficient
-    // for childless leaf nodes.
-    var n; // number of child nodes
-    if (!this.firstChild) {
-      n = 0;
-      if (node.firstChild) return false;
-    }
-    else {
-      n = this.childNodes.length;
-      if (node.childNodes.length !== n) return false;
-    }
-
     // Check type-specific properties for equality
     if (!this.isEqual(node)) return false;
 
-    // Now check children for equality
-    for(var i = 0; i < n; i++) {
-      var c1 = this.childNodes[i], c2 = node.childNodes[i];
+    // Now check children for number and equality
+    for (var c1 = this.firstChild, c2 = node.firstChild;
+         c1 && c2;
+         c1 = c1.nextSibling, c2 = c2.nextSibling) {
       if (!c1.isEqualNode(c2)) return false;
     }
-
-    return true;
+    return c1 === null && c2 === null;
   }},
 
   // This method delegates shallow cloning to a clone() method
@@ -425,9 +405,9 @@ Node.prototype = Object.create(EventTarget.prototype, {
     var clone = this.clone();
 
     // Handle the recursive case if necessary
-    if (deep && this.firstChild) {
-      for(var i = 0, n = this.childNodes.length; i < n; i++) {
-        clone._appendChild(this.childNodes[i].cloneNode(true));
+    if (deep) {
+      for (var kid = this.firstChild; kid !== null; kid = kid.nextSibling) {
+        clone._appendChild(kid.cloneNode(true));
       }
     }
 
@@ -481,12 +461,13 @@ Node.prototype = Object.create(EventTarget.prototype, {
   // Return the index of this node in its parent.
   // Throw if no parent, or if this node is not a child of its parent
   index: { get: function() {
-    utils.assert(this.parentNode);
-    var kids = this.parentNode.childNodes;
+    var parent = this.parentNode;
+    if (this === parent.firstChild) return 0; // fast case
+    var kids = parent.childNodes;
     if (this._index === undefined || kids[this._index] !== this) {
       // Ensure that we don't have an O(N^2) blowup if none of the
       // kids have defined indices yet and we're traversing via
-      // nextSibling or prevSibling
+      // nextSibling or previousSibling
       for (var i=0; i<kids.length; i++) {
         kids[i]._index = i;
       }
@@ -521,126 +502,132 @@ Node.prototype = Object.create(EventTarget.prototype, {
     }
   }},
 
-  // Remove all of this node's children.  This is a minor
-  // optimization that only calls modify() once.
-  removeChildren: { value: function removeChildren() {
-    var n = this.childNodes.length;
-    if (n) {
-      var root = this.rooted ? this.ownerDocument : null;
-      for(var i = 0; i < n; i++) {
-        if (root) root.mutateRemove(this.childNodes[i]);
-        this.childNodes[i].parentNode = null;
-      }
-      this.childNodes.length = 0; // Forget all children
-      this.modify();              // Update last modified type once only
-    }
-  }},
+  removeChildren: { value: utils.shouldOverride },
 
-  // Insert this node as a child of parent at the specified index,
-  // firing mutation events as necessary
-  insert: { value: function insert(parent, index) {
-    this._insertOrReplace(parent, index, false);
-  }},
-
-  // Insert this node as a child of parent at the specified index,
+  // Insert this node as a child of parent before the specified child,
+  // or insert as the last child of parent if specified child is null,
   // or replace the specified child with this node, firing mutation events as
   // necessary
-  _insertOrReplace: { value: function _insertOrReplace(parent, index, isReplace) {
-    var child = this;
-    var kids = parent.childNodes;
+  _insertOrReplace: { value: function _insertOrReplace(parent, before, isReplace) {
+    var child = this, before_index, i;
 
     if (child.nodeType === DOCUMENT_FRAGMENT_NODE && child.rooted) {
       utils.HierarchyRequestError();
     }
 
-    // If we are already a child of the specified parent, then
-    // the index may have to be adjusted.
-    if (child.parentNode === parent) {
-      var currentIndex = child.index;
-      // If we're not moving the node, we're done now
-      // XXX: or do DOM mutation events still have to be fired?
-      if (currentIndex === index) return;
+    /* Ensure index of `before` is cached before we (possibly) remove it. */
+    if (parent._childNodes) {
+      before_index = (before === null) ? parent._childNodes.length :
+        before.index; /* ensure _index is cached */
 
-      // If the child is before the spot it is to be inserted at,
-      // then when it is removed, the index of that spot will be
-      // reduced.
-      if (currentIndex < index) index--;
+      // If we are already a child of the specified parent, then
+      // the index may have to be adjusted.
+      if (child.parentNode === parent) {
+        var child_index = child.index;
+        // If the child is before the spot it is to be inserted at,
+        // then when it is removed, the index of that spot will be
+        // reduced.
+        if (child_index < before_index) {
+          before_index--;
+        }
+      }
     }
 
     // Delete the old child
     if (isReplace) {
-      var oldChild = parent.childNodes[index];
-      if (oldChild.rooted) oldChild.doc.mutateRemove(oldChild);
-      oldChild.parentNode = null;
+      if (before.rooted) before.doc.mutateRemove(before);
+      before.parentNode = null;
     }
+
+    var n = before;
+    if (n === null) { n = parent.firstChild; }
 
     // If both the child and the parent are rooted, then we want to
     // transplant the child without uprooting and rerooting it.
-    if (child.rooted && parent.rooted) {
-      // Remove the child from its current position in the tree
-      // without calling remove(), since we don't want to uproot it.
-      var curpar = child.parentNode;
-      curpar.childNodes.splice(child.index, 1);
-      curpar.modify();
+    var bothRooted = child.rooted && parent.rooted;
+    if (child.nodeType === DOCUMENT_FRAGMENT_NODE) {
+      var spliceArgs = [0, isReplace ? 1 : 0], next;
+      for (var kid = child.firstChild; kid !== null; kid = next) {
+        next = kid.nextSibling;
+        spliceArgs.push(kid);
+        kid.parentNode = parent;
+      }
+      var len = spliceArgs.length;
+      // Add all nodes to the new parent, overwriting the old child
+      if (isReplace) {
+        LinkedList.replace(n, len > 2 ? spliceArgs[2] : null);
+      } else if (len > 2 && n !== null) {
+        LinkedList.insertBefore(spliceArgs[2], n);
+      }
+      if (parent._childNodes) {
+        spliceArgs[0] = (before === null) ?
+          parent._childNodes.length : before._index;
+        parent._childNodes.splice.apply(parent._childNodes, spliceArgs);
+        for (i=2; i<len; i++) {
+          spliceArgs[i]._index = spliceArgs[0] + (i - 2);
+        }
+      } else if (parent._firstChild === before) {
+        if (len > 2) {
+          parent._firstChild = spliceArgs[2];
+        } else if (isReplace) {
+          parent._firstChild = null;
+        }
+      }
+      // Remove all nodes from the document fragment
+      if (child._childNodes) {
+        child._childNodes.length = 0;
+      } else {
+        child._firstChild = null;
+      }
+      // Call the mutation handlers
+      // Use spliceArgs since the original array has been destroyed. The
+      // liveness guarantee requires us to clone the array so that
+      // references to the childNodes of the DocumentFragment will be empty
+      // when the insertion handlers are called.
+      if (parent.rooted) {
+        parent.modify();
+        for (i = 2; i < len; i++) {
+          parent.doc.mutateInsert(spliceArgs[i]);
+        }
+      }
+    } else {
+      if (before === child) { return; }
+      if (bothRooted) {
+        // Remove the child from its current position in the tree
+        // without calling remove(), since we don't want to uproot it.
+        child._remove();
+      } else if (child.parentNode) {
+        child.remove();
+      }
 
-      // And insert it as a child of its new parent
+      // Insert it as a child of its new parent
       child.parentNode = parent;
       if (isReplace) {
-        kids[index] = child;
+        LinkedList.replace(n, child);
+        if (parent._childNodes) {
+          child._index = before_index;
+          parent._childNodes[before_index] = child;
+        } else if (parent._firstChild === before) {
+          parent._firstChild = child;
+        }
       } else {
-        kids.splice(index, 0, child);
-      }
-      child._index = index;
-      parent.modify();
-
-      // Generate a move mutation event
-      parent.doc.mutateMove(child);
-    }
-    else {
-      if (child.nodeType === DOCUMENT_FRAGMENT_NODE) {
-        var spliceArgs = [index, isReplace ? 1 : 0];
-        var i;
-        for (i = 0; i < child.childNodes.length; i++) {
-          var fragChild = child.childNodes[i];
-          spliceArgs.push(fragChild);
-          fragChild.parentNode = parent;
-          fragChild._index = index + i;
+        if (n !== null) {
+          LinkedList.insertBefore(child, n);
         }
-        // Remove all nodes from the document fragment
-        child.childNodes.length = 0;
-        // Add all nodes to the new parent, overwriting the old child
-        kids.splice.apply(kids, spliceArgs);
-        // Call the mutation handlers
-        // Use spliceArgs since the original array has been destroyed. The
-        // liveness guarantee requires us to clone the array so that
-        // references to the childNodes of the DocumentFragment will be empty
-        // when the insertion handlers are called.
-        if (parent.rooted) {
-          parent.modify();
-          for (i = 2; i < spliceArgs.length; i++) {
-            parent.doc.mutateInsert(spliceArgs[i]);
-          }
+        if (parent._childNodes) {
+          child._index = before_index;
+          parent._childNodes.splice(before_index, 0, child);
+        } else if (parent._firstChild === before) {
+          parent._firstChild = child;
         }
       }
-      else {
-        // If the child already has a parent, it needs to be
-        // removed from that parent, which may also uproot it
-        if (child.parentNode) child.remove();
-
-        // Now insert the child into the parent's array of children
-        child.parentNode = parent;
-        if (isReplace) {
-          kids[index] = child;
-        } else {
-          kids.splice(index, 0, child);
-        }
-        child._index = index;
-
-        // And root the child if necessary
-        if (parent.rooted) {
-          parent.modify();
-          parent.doc.mutateInsert(child);
-        }
+      if (bothRooted) {
+        parent.modify();
+        // Generate a move mutation event
+        parent.doc.mutateMove(child);
+      } else if (parent.rooted) {
+        parent.modify();
+        parent.doc.mutateInsert(child);
       }
     }
   }},
@@ -694,8 +681,9 @@ Node.prototype = Object.create(EventTarget.prototype, {
   }},
 
   normalize: { value: function() {
-    for (var i=0; i < this.childNodes.length; i++) {
-      var child = this.childNodes[i];
+    var next;
+    for (var child=this.firstChild; child !== null; child=next) {
+      next = child.nextSibling;
 
       if (child.normalize) {
         child.normalize();
@@ -707,20 +695,16 @@ Node.prototype = Object.create(EventTarget.prototype, {
 
       if (child.nodeValue === "") {
         this.removeChild(child);
-        i--;
         continue;
       }
 
-      if (i) {
-        var prevChild = this.childNodes[i-1];
-
-        if (prevChild.nodeType === Node.TEXT_NODE) {
-          // remove the child and decrement i
-          prevChild.appendData(child.nodeValue);
-
-          this.removeChild(child);
-          i--;
-        }
+      var prevChild = child.previousSibling;
+      if (prevChild === null) {
+        continue;
+      } else if (prevChild.nodeType === Node.TEXT_NODE) {
+        // merge this with previous and remove the child
+        prevChild.appendData(child.nodeValue);
+        this.removeChild(child);
       }
     }
   }},
@@ -731,9 +715,14 @@ Node.prototype = Object.create(EventTarget.prototype, {
   // http://www.whatwg.org/specs/web-apps/current-work/multipage/the-end.html#serializing-html-fragments
   serialize: { value: function() {
     var s = '';
-    for(var i = 0, n = this.childNodes.length; i < n; i++) {
-      var kid = this.childNodes[i];
-      switch(kid.nodeType) {
+    for (var kid = this.firstChild; kid !== null; kid = kid.nextSibling) {
+      s += kid._serializeOne(this);
+    }
+    return s;
+  }},
+  _serializeOne: { value: function(parent) {
+    var kid = this, s = '';
+    switch(kid.nodeType) {
       case 1: //ELEMENT_NODE
         var ns = kid.namespaceURI;
         var html = ns === NAMESPACE.HTML;
@@ -759,14 +748,14 @@ Node.prototype = Object.create(EventTarget.prototype, {
       case 3: //TEXT_NODE
       case 4: //CDATA_SECTION_NODE
         var parenttag;
-        if (this.nodeType === ELEMENT_NODE &&
-          this.namespaceURI === NAMESPACE.HTML)
-          parenttag = this.tagName;
+        if (parent.nodeType === ELEMENT_NODE &&
+          parent.namespaceURI === NAMESPACE.HTML)
+          parenttag = parent.tagName;
         else
           parenttag = '';
 
         if (hasRawContent[parenttag] ||
-            (parenttag==='NOSCRIPT' && this.ownerDocument._scripting_enabled)) {
+            (parenttag==='NOSCRIPT' && parent.ownerDocument._scripting_enabled)) {
           s += kid.data;
         } else {
           s += escape(kid.data);
@@ -796,9 +785,7 @@ Node.prototype = Object.create(EventTarget.prototype, {
         break;
       default:
         utils.InvalidState();
-      }
     }
-
     return s;
   }},
 

--- a/lib/NonDocumentTypeChildNode.js
+++ b/lib/NonDocumentTypeChildNode.js
@@ -5,9 +5,8 @@ var NonDocumentTypeChildNode = {
 
   nextElementSibling: { get: function() {
     if (this.parentNode) {
-      var sibs = this.parentNode.childNodes;
-      for(var i = this.index+1, n = sibs.length; i < n; i++) {
-        if (sibs[i].nodeType === Node.ELEMENT_NODE) return sibs[i];
+      for (var kid = this.nextSibling; kid !== null; kid = kid.nextSibling) {
+        if (kid.nodeType === Node.ELEMENT_NODE) return kid;
       }
     }
     return null;
@@ -15,9 +14,8 @@ var NonDocumentTypeChildNode = {
 
   previousElementSibling: { get: function() {
     if (this.parentNode) {
-      var sibs = this.parentNode.childNodes;
-      for(var i = this.index-1; i >= 0; i--) {
-        if (sibs[i].nodeType === Node.ELEMENT_NODE) return sibs[i];
+      for (var kid = this.previousSibling; kid !== null; kid = kid.previousSibling) {
+        if (kid.nodeType === Node.ELEMENT_NODE) return kid;
       }
     }
     return null;

--- a/lib/ProcessingInstruction.js
+++ b/lib/ProcessingInstruction.js
@@ -5,6 +5,7 @@ var Node = require('./Node');
 var CharacterData = require('./CharacterData');
 
 function ProcessingInstruction(doc, target, data) {
+  CharacterData.call(this);
   this.nodeType = Node.PROCESSING_INSTRUCTION_NODE;
   this.ownerDocument = doc;
   this.target = target;

--- a/lib/Text.js
+++ b/lib/Text.js
@@ -6,6 +6,7 @@ var Node = require('./Node');
 var CharacterData = require('./CharacterData');
 
 function Text(doc, data) {
+  CharacterData.call(this);
   this.nodeType = Node.TEXT_NODE;
   this.ownerDocument = doc;
   this._data = data;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -41,6 +41,10 @@ exports.nyi = function() {
   throw new Error("NotYetImplemented");
 };
 
+exports.shouldOverride = function() {
+  throw new Error("Abstract function; should be overriding in subclass.");
+};
+
 exports.assert = function(expr, msg) {
   if (!expr) {
     throw new Error("Assertion failed: " + (msg || "") + "\n" + new Error().stack);


### PR DESCRIPTION
Posted for early review.  This changes the backing implementation of domino to use circular doubly-linked lists for the sibling list, instead of the array required by the `childNodes` accessor.  This offers a high performance mutation interface for those who don't need the random access to the child list provided by `childNodes`.