### PR TITLE
#129 ContainerNode removeChildren() leaves parent pointers behind

### DIFF
--- a/lib/ContainerNode.js
+++ b/lib/ContainerNode.js
@@ -59,8 +59,13 @@ ContainerNode.prototype = Object.create(Node.prototype, {
   // Remove all of this node's children.  This is a minor
   // optimization that only calls modify() once.
   removeChildren: { value: function removeChildren() {
-    var root = this.rooted ? this.ownerDocument : null;
-    for (var kid = this.firstChild; kid !== null; kid = kid.nextSibling) {
+    var root = this.rooted ? this.ownerDocument : null,
+        next = this.firstChild,
+        kid;
+    while (next !== null) {
+      kid = next;
+      next = kid.nextSibling;
+
       if (root) root.mutateRemove(kid);
       kid.parentNode = null;
     }

--- a/test/domino.js
+++ b/test/domino.js
@@ -1120,3 +1120,13 @@ exports.gh128 = function() {
     }
   });
 };
+
+exports.gh129 = function() {
+  var window = domino.createWindow();
+  var document = window.document;
+  var div = document.body.appendChild(document.createElement('div'));
+  div.innerHTML = '<p></p><span></span>';
+  var span = div.firstChild.nextSibling;
+  div.textContent = '';
+  (span.parentNode === null).should.equal(true);
+};


### PR DESCRIPTION
See the issue ticket #129 for a description of what happens here, but in
essence, the problem is that removeChildren() tries to null each kid
parentNode then navigate to the following sibling with nextSibling, but
nextSibling will never return anything if it doesn't have a parent.

So we track nextSibling first, then null the parentNode.