### PR TITLE
Fix $= selector

### DIFF
--- a/lib/select.js
+++ b/lib/select.js
@@ -519,7 +519,8 @@ var operators = {
     return attr.indexOf(val) === 0;
   },
   '$=': function(attr, val) {
-    return attr.indexOf(val) + val.length === attr.length;
+    var i = attr.indexOf(val);
+    return i !== -1 && i + val.length === attr.length;
   },
   // non-standard
   '!=': function(attr, val) {

--- a/test/domino.js
+++ b/test/domino.js
@@ -1180,6 +1180,12 @@ exports.gh129 = function() {
   (span.parentNode === null).should.equal(true);
 };
 
+exports.gh135 = function() {
+  var document = domino.createDocument('<a target="foobar"></a>');
+  var a = document.querySelectorAll('*[target$="aaaaaaa"]');
+  a.length.should.equal(0);
+};
+
 // Examples from
 // https://developer.mozilla.org/en-US/docs/Web/API/Element/outerHTML
 exports.outerHTML1 = function() {


### PR DESCRIPTION
Zest's $= check used indexOf() without checking for -1 and then did a
length check, so if the test string happened to be one character longer
than the attribute value, it returned true, even if the string didn't
match.

Nothing really to put in a test here, since this was just an edge case.