### PR TITLE
Avoid megamorphic call-site for `Node#_serializeOne()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # domino x.x.x (not yet released)
 * Allow writable Element constructors unless __domino_frozen__ is set to true (#138)
 * Bug fix for CSS `$=` selector. (#135)
+* Move `Node#_serializeOne()` to `NodeUtils.serializeOne()` to reduce pressure
+  on the megamorphic stub cache in V8, and thereby improve throughput (#142).
 
 # domino 2.1.1 (30 Nov 2018)
 * Add `domino.createIncrementalHTMLParser` interface.

--- a/lib/Element.js
+++ b/lib/Element.js
@@ -7,6 +7,7 @@ var NAMESPACE = utils.NAMESPACE;
 var attributes = require('./attributes');
 var Node = require('./Node');
 var NodeList = require('./NodeList');
+var NodeUtils = require('./NodeUtils');
 var FilteredElementList = require('./FilteredElementList');
 var DOMException = require('./DOMException');
 var DOMTokenList = require('./DOMTokenList');
@@ -98,7 +99,7 @@ Element.prototype = Object.create(ContainerNode.prototype, {
       // "the attribute must return the result of running the HTML fragment
       // serialization algorithm on a fictional node whose only child is
       // the context object"
-      return this._serializeOne({ nodeType: 0 });
+      return NodeUtils.serializeOne(this, { nodeType: 0 });
     },
     set: function(v) {
       var document = this.ownerDocument;

--- a/lib/Element.js
+++ b/lib/Element.js
@@ -99,6 +99,14 @@ Element.prototype = Object.create(ContainerNode.prototype, {
       // "the attribute must return the result of running the HTML fragment
       // serialization algorithm on a fictional node whose only child is
       // the context object"
+      //
+      // The serialization logic is intentionally implemented in a separate
+      // `NodeUtils` helper instead of the more obvious choice of a private
+      // `_serializeOne()` method on the `Node.prototype` in order to avoid
+      // the megamorphic `this._serializeOne` property access, which reduces
+      // performance unnecessarily. If you need specialized behavior for a
+      // certain subclass, you'll need to implement that in `NodeUtils`.
+      // See https://github.com/fgnass/domino/pull/142 for more information.
       return NodeUtils.serializeOne(this, { nodeType: 0 });
     },
     set: function(v) {

--- a/lib/Node.js
+++ b/lib/Node.js
@@ -3,8 +3,8 @@ module.exports = Node;
 
 var EventTarget = require('./EventTarget');
 var LinkedList = require('./LinkedList');
+var NodeUtils = require('./NodeUtils');
 var utils = require('./utils');
-var NAMESPACE = utils.NAMESPACE;
 
 // All nodes have a nodeType and an ownerDocument.
 // Once inserted, they also have a parentNode.
@@ -37,45 +37,6 @@ var DOCUMENT_POSITION_FOLLOWING               = Node.DOCUMENT_POSITION_FOLLOWING
 var DOCUMENT_POSITION_CONTAINS                = Node.DOCUMENT_POSITION_CONTAINS = 0x08;
 var DOCUMENT_POSITION_CONTAINED_BY            = Node.DOCUMENT_POSITION_CONTAINED_BY = 0x10;
 var DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC = Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC = 0x20;
-
-var hasRawContent = {
-  STYLE: true,
-  SCRIPT: true,
-  XMP: true,
-  IFRAME: true,
-  NOEMBED: true,
-  NOFRAMES: true,
-  PLAINTEXT: true
-};
-
-var emptyElements = {
-  area: true,
-  base: true,
-  basefont: true,
-  bgsound: true,
-  br: true,
-  col: true,
-  embed: true,
-  frame: true,
-  hr: true,
-  img: true,
-  input: true,
-  keygen: true,
-  link: true,
-  meta: true,
-  param: true,
-  source: true,
-  track: true,
-  wbr: true
-};
-
-var extraNewLine = {
-  /* Removed in https://github.com/whatwg/html/issues/944
-  pre: true,
-  textarea: true,
-  listing: true
-  */
-};
 
 Node.prototype = Object.create(EventTarget.prototype, {
 
@@ -732,75 +693,7 @@ Node.prototype = Object.create(EventTarget.prototype, {
   serialize: { value: function() {
     var s = '';
     for (var kid = this.firstChild; kid !== null; kid = kid.nextSibling) {
-      s += kid._serializeOne(this);
-    }
-    return s;
-  }},
-  _serializeOne: { value: function(parent) {
-    var kid = this, s = '';
-    switch(kid.nodeType) {
-      case 1: //ELEMENT_NODE
-        var ns = kid.namespaceURI;
-        var html = ns === NAMESPACE.HTML;
-        var tagname = (html || ns === NAMESPACE.SVG || ns === NAMESPACE.MATHML) ? kid.localName : kid.tagName;
-
-        s += '<' + tagname;
-
-        for(var j = 0, k = kid._numattrs; j < k; j++) {
-          var a = kid._attr(j);
-          s += ' ' + attrname(a);
-          if (a.value !== undefined) s += '="' + escapeAttr(a.value) + '"';
-        }
-        s += '>';
-
-        if (!(html && emptyElements[tagname])) {
-          var ss = kid.serialize();
-          if (html && extraNewLine[tagname] && ss.charAt(0)==='\n') s += '\n';
-          // Serialize children and add end tag for all others
-          s += ss;
-          s += '</' + tagname + '>';
-        }
-        break;
-      case 3: //TEXT_NODE
-      case 4: //CDATA_SECTION_NODE
-        var parenttag;
-        if (parent.nodeType === ELEMENT_NODE &&
-          parent.namespaceURI === NAMESPACE.HTML)
-          parenttag = parent.tagName;
-        else
-          parenttag = '';
-
-        if (hasRawContent[parenttag] ||
-            (parenttag==='NOSCRIPT' && parent.ownerDocument._scripting_enabled)) {
-          s += kid.data;
-        } else {
-          s += escape(kid.data);
-        }
-        break;
-      case 8: //COMMENT_NODE
-        s += '<!--' + kid.data + '-->';
-        break;
-      case 7: //PROCESSING_INSTRUCTION_NODE
-        s += '<?' + kid.target + ' ' + kid.data + '?>';
-        break;
-      case 10: //DOCUMENT_TYPE_NODE
-        s += '<!DOCTYPE ' + kid.name;
-
-        if (false) {
-          // Latest HTML serialization spec omits the public/system ID
-          if (kid.publicID) {
-            s += ' PUBLIC "' + kid.publicId + '"';
-          }
-
-          if (kid.systemId) {
-            s += ' "' + kid.systemId + '"';
-          }
-        }
-
-        s += '>';
-        break;
-      default:
-        utils.InvalidState();
+      s += NodeUtils.serializeOne(kid, this);
     }
     return s;
   }},
@@ -808,7 +701,7 @@ Node.prototype = Object.create(EventTarget.prototype, {
   // Non-standard, but often useful for debugging.
   outerHTML: {
     get: function() {
-      return this._serializeOne({ nodeType: 0 });
+      return NodeUtils.serializeOne(this, { nodeType: 0 });
     },
     set: utils.nyi,
   },
@@ -835,46 +728,3 @@ Node.prototype = Object.create(EventTarget.prototype, {
   DOCUMENT_POSITION_CONTAINED_BY: { value: DOCUMENT_POSITION_CONTAINED_BY },
   DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC: { value: DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC },
 });
-
-function escape(s) {
-  return s.replace(/[&<>\u00A0]/g, function(c) {
-    switch(c) {
-    case '&': return '&amp;';
-    case '<': return '&lt;';
-    case '>': return '&gt;';
-    case '\u00A0': return '&nbsp;';
-    }
-  });
-}
-
-function escapeAttr(s) {
-  var toEscape = /[&"\u00A0]/g;
-  if (!toEscape.test(s)) {
-      // nothing to do, fast path
-      return s;
-  } else {
-      return s.replace(toEscape, function(c) {
-        switch(c) {
-        case '&': return '&amp;';
-        case '"': return '&quot;';
-        case '\u00A0': return '&nbsp;';
-        }
-      });
-  }
-}
-
-function attrname(a) {
-  var ns = a.namespaceURI;
-  if (!ns)
-    return a.localName;
-  if (ns === NAMESPACE.XML)
-    return 'xml:' + a.localName;
-  if (ns === NAMESPACE.XLINK)
-    return 'xlink:' + a.localName;
-
-  if (ns === NAMESPACE.XMLNS) {
-    if (a.localName === 'xmlns') return 'xmlns';
-    else return 'xmlns:' + a.localName;
-  }
-  return a.name;
-}

--- a/lib/Node.js
+++ b/lib/Node.js
@@ -690,6 +690,14 @@ Node.prototype = Object.create(EventTarget.prototype, {
   // This is used by the innerHTML getter
   // The serialization spec is at:
   // http://www.whatwg.org/specs/web-apps/current-work/multipage/the-end.html#serializing-html-fragments
+  //
+  // The serialization logic is intentionally implemented in a separate
+  // `NodeUtils` helper instead of the more obvious choice of a private
+  // `_serializeOne()` method on the `Node.prototype` in order to avoid
+  // the megamorphic `this._serializeOne` property access, which reduces
+  // performance unnecessarily. If you need specialized behavior for a
+  // certain subclass, you'll need to implement that in `NodeUtils`.
+  // See https://github.com/fgnass/domino/pull/142 for more information.
   serialize: { value: function() {
     var s = '';
     for (var kid = this.firstChild; kid !== null; kid = kid.nextSibling) {

--- a/lib/NodeUtils.js
+++ b/lib/NodeUtils.js
@@ -1,5 +1,15 @@
 "use strict";
 module.exports = {
+  // NOTE: The `serializeOne()` function used to live on the `Node.prototype`
+  // as a private method `Node#_serializeOne(child)`, however that requires
+  // a megamorphic property access `this._serializeOne` just to get to the
+  // method, and this is being done on lots of different `Node` subclasses,
+  // which puts a lot of pressure on V8's megamorphic stub cache. So by
+  // moving the helper off of the `Node.prototype` and into a separate
+  // function in this helper module, we get a monomorphic property access
+  // `NodeUtils.serializeOne` to get to the function and reduce pressure
+  // on the megamorphic stub cache.
+  // See https://github.com/fgnass/domino/pull/142 for more information.
   serializeOne: serializeOne
 };
 

--- a/lib/NodeUtils.js
+++ b/lib/NodeUtils.js
@@ -1,0 +1,158 @@
+"use strict";
+module.exports = {
+  serializeOne: serializeOne
+};
+
+var utils = require('./utils');
+var NAMESPACE = utils.NAMESPACE;
+
+var hasRawContent = {
+  STYLE: true,
+  SCRIPT: true,
+  XMP: true,
+  IFRAME: true,
+  NOEMBED: true,
+  NOFRAMES: true,
+  PLAINTEXT: true
+};
+
+var emptyElements = {
+  area: true,
+  base: true,
+  basefont: true,
+  bgsound: true,
+  br: true,
+  col: true,
+  embed: true,
+  frame: true,
+  hr: true,
+  img: true,
+  input: true,
+  keygen: true,
+  link: true,
+  meta: true,
+  param: true,
+  source: true,
+  track: true,
+  wbr: true
+};
+
+var extraNewLine = {
+  /* Removed in https://github.com/whatwg/html/issues/944
+  pre: true,
+  textarea: true,
+  listing: true
+  */
+};
+
+function escape(s) {
+  return s.replace(/[&<>\u00A0]/g, function(c) {
+    switch(c) {
+    case '&': return '&amp;';
+    case '<': return '&lt;';
+    case '>': return '&gt;';
+    case '\u00A0': return '&nbsp;';
+    }
+  });
+}
+
+function escapeAttr(s) {
+  var toEscape = /[&"\u00A0]/g;
+  if (!toEscape.test(s)) {
+      // nothing to do, fast path
+      return s;
+  } else {
+      return s.replace(toEscape, function(c) {
+        switch(c) {
+        case '&': return '&amp;';
+        case '"': return '&quot;';
+        case '\u00A0': return '&nbsp;';
+        }
+      });
+  }
+}
+
+function attrname(a) {
+  var ns = a.namespaceURI;
+  if (!ns)
+    return a.localName;
+  if (ns === NAMESPACE.XML)
+    return 'xml:' + a.localName;
+  if (ns === NAMESPACE.XLINK)
+    return 'xlink:' + a.localName;
+
+  if (ns === NAMESPACE.XMLNS) {
+    if (a.localName === 'xmlns') return 'xmlns';
+    else return 'xmlns:' + a.localName;
+  }
+  return a.name;
+}
+
+function serializeOne(kid, parent) {
+  var s = '';
+  switch(kid.nodeType) {
+    case 1: //ELEMENT_NODE
+      var ns = kid.namespaceURI;
+      var html = ns === NAMESPACE.HTML;
+      var tagname = (html || ns === NAMESPACE.SVG || ns === NAMESPACE.MATHML) ? kid.localName : kid.tagName;
+
+      s += '<' + tagname;
+
+      for(var j = 0, k = kid._numattrs; j < k; j++) {
+        var a = kid._attr(j);
+        s += ' ' + attrname(a);
+        if (a.value !== undefined) s += '="' + escapeAttr(a.value) + '"';
+      }
+      s += '>';
+
+      if (!(html && emptyElements[tagname])) {
+        var ss = kid.serialize();
+        if (html && extraNewLine[tagname] && ss.charAt(0)==='\n') s += '\n';
+        // Serialize children and add end tag for all others
+        s += ss;
+        s += '</' + tagname + '>';
+      }
+      break;
+    case 3: //TEXT_NODE
+    case 4: //CDATA_SECTION_NODE
+      var parenttag;
+      if (parent.nodeType === 1 /*ELEMENT_NODE*/ &&
+        parent.namespaceURI === NAMESPACE.HTML)
+        parenttag = parent.tagName;
+      else
+        parenttag = '';
+
+      if (hasRawContent[parenttag] ||
+          (parenttag==='NOSCRIPT' && parent.ownerDocument._scripting_enabled)) {
+        s += kid.data;
+      } else {
+        s += escape(kid.data);
+      }
+      break;
+    case 8: //COMMENT_NODE
+      s += '<!--' + kid.data + '-->';
+      break;
+    case 7: //PROCESSING_INSTRUCTION_NODE
+      s += '<?' + kid.target + ' ' + kid.data + '?>';
+      break;
+    case 10: //DOCUMENT_TYPE_NODE
+      s += '<!DOCTYPE ' + kid.name;
+
+      if (false) {
+        // Latest HTML serialization spec omits the public/system ID
+        if (kid.publicID) {
+          s += ' PUBLIC "' + kid.publicId + '"';
+        }
+
+        if (kid.systemId) {
+          s += ' "' + kid.systemId + '"';
+        }
+      }
+
+      s += '>';
+      break;
+    default:
+      utils.InvalidStateError();
+  }
+  return s;
+}


### PR DESCRIPTION
This adds a `NodeUtils` helper object, and moves the
`Node#_serializeOne()` there, to avoid the lookup of the
`_serializeOne()` method on the prototype in various places. The problem
with code like

```js
str = this._serializeOne(parent);
```

is that it's called with various different shapes for `this` (i.e.
different `Node` subclass instances), and thus this property access is
going to be *MEGAMORPHIC* in any realistic application. In Node.js this
will hit the so-called *megamorphic stub cache* in V8, which is a global
resource used to cache megamorphic lookups. Having lot's of contention
on this global resource is going to affect various different parts of
the application (i.e. it's a non-local effect on overall performance).
So anything that can be done to reduce the number of megamorphic
property accesses is going to eventually help with performance. The
problem can be avoided easily for `_serializeOne()` by moving the method
off of the `Node.prototype` and into a separate `NodeUtils` helper
object instead.

On a simple Angular Universal [prerender test case][1] (using domino)
this can greatly reduce the number of megamorphic stub cache misses -
i.e. the times when V8 hits the super slow path and has to redo the
full property lookup via the prototype chain - for `LoadIC`s from around
1518983 to 1255967, which corresponds to a **17%** reduction.

Similar improvements could be made for `Node#_countChildrenOfType()`,
`Node#_ensureInsertValid()` and `Node#_insertOrReplace()`, although
that might be less impactful overall.

[1]:
https://gist.githubusercontent.com/bmeurer/5b9480ef1a74c5187180193abc73dcd4/raw/fc5d9a01a6b7fe841efa1c7773ae55e70435d16a/prerender.js