### PR TITLE
Fix TypeError in Element.closest when no match is found

### DIFF
--- a/lib/Element.js
+++ b/lib/Element.js
@@ -922,7 +922,7 @@ Element.prototype = Object.create(ContainerNode.prototype, {
 
   closest: { value: function(selector) {
     var el = this;
-    while (el.matches && !el.matches(selector)) el = el.parentNode;
+    while (el.matches && !el.matches(selector) && el.parentNode) el = el.parentNode;
     return el.matches ? el : null;
   }},
 


### PR DESCRIPTION
Currently, when Element.closest reaches the top of the DOM tree without
finding a match, a TypeError is thrown when attempting to read the
'matches' property of the Document node's parentNode (null). This patch
adds a check that el.parentNode exists to the loop conditional so that
we break out as expected without throwing.

Bug: T240682