### PR TITLE
Remove the testing files from release.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "domino",
-  "version": "2.1.4",
+  "version": "2.1.4+git",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "domino",
-  "version": "2.1.4+git",
+  "version": "2.1.5",
   "license": "BSD-2-Clause",
   "author": "Felix Gnass <fgnass@gmail.com>",
   "description": "Server-side DOM implementation based on Mozilla's dom.js",
@@ -10,6 +10,11 @@
     "type": "git",
     "url": "https://github.com/fgnass/domino.git"
   },
+  "files": [
+    "lib",
+    "CHANGELOG.md",
+    "README.md"
+  ],
   "scripts": {
     "lint": "jshint lib test/*.js",
     "mocha": "./node_modules/.bin/mocha",


### PR DESCRIPTION
Resolves a vulnerability detected by some scanners such as Sonatype Nexus IQ.

Tested using `npm pack` and a project that depends on domino through @angular/platform-server. 

Not sure what to do with the version after looking at the tools/* directory.  I just went ahead and bumped it, looks like the scripts are designed around that.

Fixes #161 