### PR TITLE
DOMTokenList: Reuse index from DOMTokenList instance if possible …

### DIFF
--- a/lib/DOMTokenList.js
+++ b/lib/DOMTokenList.js
@@ -1,6 +1,5 @@
 "use strict";
 // DOMTokenList implementation based on https://github.com/Raynos/DOM-shim
-// XXX: should cache the getList(this) value more aggressively!
 var utils = require('./utils');
 
 module.exports = DOMTokenList;
@@ -9,6 +8,7 @@ function DOMTokenList(getter, setter) {
   this._getString = getter;
   this._setString = setter;
   this._length = 0;
+  this._lastStringValue = '';
   this._update();
 }
 
@@ -129,6 +129,7 @@ Object.defineProperties(DOMTokenList.prototype, {
     } else {
       fixIndex(this, getList(this));
     }
+    this._lastStringValue = this._getString();
   } },
 });
 
@@ -156,8 +157,21 @@ function handleErrors(token) {
   return token;
 }
 
+function toArray(clist) {
+  var length = clist._length;
+  var arr = Array(length);
+  for (var i = 0; i < length; i++) {
+    arr[i] = clist[i];
+  }
+  return arr;
+}
+
 function getList(clist) {
-  var str = clist._getString().replace(/(^[ \t\r\n\f]+)|([ \t\r\n\f]+$)/g, '');
+  var strProp = clist._getString();
+  if (strProp === clist._lastStringValue) {
+    return toArray(clist);
+  }
+  var str = strProp.replace(/(^[ \t\r\n\f]+)|([ \t\r\n\f]+$)/g, '');
   if (str === "") {
     return [];
   } else {


### PR DESCRIPTION
…instead of parsing raw string attribute every time

In our Angular Universal app we extensively use utility classes that can be toggled conditionally.
While investigation recent performance issues, I noticed that the single longest-running piece of code is `getList` function from DOMTokenList. Looks like adding multiple classes to a dom element one by one is O(N^2), as at each step getList is called and parses the raw string property into a list of tokens. This parsing seems to be quite a heavy operation.

This PR implements a way to avoid unnecessary parsing by reusing results from the previous step.

In our project this change reduced the class list processing time by half.