### PR TITLE
wrap/replace eval calls with function constructor calls to make the sloppy file strict-mode compliant

### DIFF
--- a/lib/sloppy.js
+++ b/lib/sloppy.js
@@ -1,24 +1,19 @@
 /* Domino uses sloppy-mode features (in particular, `with`) for a few
  * minor things.  This file encapsulates all the sloppiness; every
  * other module should be strict. */
-/* jshint strict: false */
 /* jshint evil: true */
-/* jshint -W085 */
 module.exports = {
   Window_run: function _run(code, file) {
+    "use strict";
     if (file) code += '\n//@ sourceURL=' + file;
-    with(this) eval(code);
+    new Function("code", "with(this) eval(code)").call(this, code);
   },
   EventHandlerBuilder_build: function build() {
+    "use strict";
     try {
-      with(this.document.defaultView || Object.create(null))
-        with(this.document)
-          with(this.form)
-            with(this.element)
-              return eval("(function(event){" + this.body + "})");
-    }
-    catch (err) {
-      return function() { throw err; };
+      return new Function("defaultView", "document", "form", "element", "event", "with(defaultView)with(document)with(form)with(element){"+this.body+"};").bind(this, this.document.defaultView || Object.create(null), this.document, this.form, this.element);
+    } catch (err) {
+      return function () { throw err; };
     }
   }
 };


### PR DESCRIPTION
Any problem in computer science can be solved by adding another layer of indirection.

This fixes all issues related with sloppy.js not being strict-mode compliant like #170 and #153 
Aside from that it also provides a better separation between the evaluated code and domino as the evaluated code can no longer accidentally fall through to variables like `file`, `require` or `__dirname` because the function constructor code is always evaluated at top-level (where these do not exist)